### PR TITLE
Fix the page header to be Azure Firewall, not Fortigate specific

### DIFF
--- a/docs/archetypes/hubnetwork-azfw.md
+++ b/docs/archetypes/hubnetwork-azfw.md
@@ -1,4 +1,4 @@
-# Archetype: Hub Networking with Fortigate Firewalls
+# Archetype: Hub Networking with Azure Firewall
 
 ## Table of Contents
 


### PR DESCRIPTION
## Overview/Summary

Just a quick typo fix on the page header.

## This PR fixes/adds/changes/removes

1. Changes Fortigate to Azure Firewall in page header

### Breaking Changes

None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x ] Updated relevant and associated documentation.
