### PR TITLE
Ensure resource tags added to log analytics workspace solutions and automation account link

### DIFF
--- a/azresources/monitor/log-analytics.bicep
+++ b/azresources/monitor/log-analytics.bicep
@@ -58,6 +58,7 @@ resource workspace 'Microsoft.OperationalInsights/workspaces@2020-08-01' = {
 // Link Log Analytics Workspace to Automation Account
 resource automationAccountLinkedToWorkspace 'Microsoft.OperationalInsights/workspaces/linkedServices@2020-08-01' = {
   name: '${workspace.name}/Automation'
+  tags: tags
   properties: {
     resourceId: automationAccount.outputs.automationAccountId
   }
@@ -66,6 +67,7 @@ resource automationAccountLinkedToWorkspace 'Microsoft.OperationalInsights/works
 // Add Log Analytics Workspace Solutions
 resource workspaceSolutions 'Microsoft.OperationsManagement/solutions@2015-11-01-preview' = [for solution in solutions: {
   name: '${solution}(${workspace.name})'
+  tags: tags
   location: resourceGroup().location
   properties: {
     workspaceResourceId: workspace.id


### PR DESCRIPTION
Log Analytics workspace is created before any Azure Policy assignments and we miss on the capability to automatically tag resources based on tags defined on the Resource Group.  Therefore, we need to make sure all required tags are applied explicitly when Logging resources are created (i.e. all resources created as part of `platform-logging-ci` pipeline).  This tag setup was missed when:

* Creating Log Analytics Workspace solutions
* Linking Log Analytics to Automation Account

Since these tags were missed, Azure Policy marked these resources as non-compliant (i.e. tags such as ClientOrganization, TechnicalContact, ProjectName, etc.)

This is a special case since all other deployments occur after Policy assignments are completed and we can take advantage of Policy based automatic tag creation.