### PR TITLE
Updated ARM API version for recovery vault (#103)

### DIFF
--- a/azresources/management/backup-recovery-vault.bicep
+++ b/azresources/management/backup-recovery-vault.bicep
@@ -22,7 +22,7 @@ var skuTier = 'Standard'
 
 
 
-resource recoveryServicesVault 'Microsoft.RecoveryServices/vaults@2020-02-02' = {
+resource recoveryServicesVault 'Microsoft.RecoveryServices/vaults@2021-08-01' = {
   name: vaultName
   location: resourceGroup().location
   tags: tags


### PR DESCRIPTION
## Overview/Summary
Updated the Recovery Services Vault Bicep API to Microsoft.RecoveryServices/vaults@2021-08-01


## This PR fixes/adds/changes/removes
The error "The property "tier" is not allowed on objects of type "Sku". No other properties are allowed." in the Bicep API version Microsoft.RecoveryServices/vaults@2020-02-02

Fixes #101

### Breaking Changes
N/A

## Testing Evidence
.\test-all.ps1 -TestFolder . -SchemaFolder ../../schemas/latest/landingzones/ ===> Passed

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
