### PR TITLE
Policy defintion for LA Diag backup and ASR Events

### DIFF
--- a/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-Backup/azurepolicy.config.json
+++ b/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-Backup/azurepolicy.config.json
@@ -1,4 +1,4 @@
 {
     "name": "Deploy Diagnostic Settings for Recovery Vault for Azure Backup Events",
-    "mode": "all"
+    "mode": "indexed"
 }

--- a/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-Backup/azurepolicy.config.json
+++ b/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-Backup/azurepolicy.config.json
@@ -1,0 +1,4 @@
+{
+    "name": "Deploy Diagnostic Settings for Recovery Vault for Azure Backup Events",
+    "mode": "all"
+}

--- a/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-Backup/azurepolicy.parameters.json
+++ b/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-Backup/azurepolicy.parameters.json
@@ -1,0 +1,57 @@
+{
+  "profileName": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Profile Name for Config",
+      "description": "The profile name Azure Diagnostics"
+    }
+  },
+  "logAnalytics": {
+    "type": "string",
+    "metadata": {
+      "displayName": "logAnalytics",
+      "description": "The target Log Analytics Workspace for Azure Diagnostics",
+      "strongType": "omsWorkspace"
+    }
+  },
+  "azureRegions": {
+    "type": "Array",
+    "metadata": {
+      "displayName": "Allowed Locations",
+      "description": "The list of locations that can be specified when deploying resources",
+      "strongType": "location"
+    }
+  },
+  "metricsEnabled": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Enable Metrics",
+      "description": "Enable Metrics - True or False"
+    },
+    "allowedValues": [
+      "True",
+      "False"
+    ],
+    "defaultValue": "False"
+  },
+  "logsEnabled": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Enable Logs",
+      "description": "Enable Logs - True or False"
+    },
+    "allowedValues": [
+      "True",
+      "False"
+    ],
+    "defaultValue": "True"
+  },
+  "diagnosticsSettingNameToUse": {
+    "type": "string",
+    "metadata": {
+      "displayName": "Setting name",
+      "description": "Name of the policy for the diagnostics settings."
+    },
+    "defaultValue": "setByPolicy-backup"
+  }
+}

--- a/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-Backup/azurepolicy.rules.json
+++ b/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-Backup/azurepolicy.rules.json
@@ -54,7 +54,7 @@
       },
       "roleDefinitionIds": [
         "/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293",
-        "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+        "/providers/Microsoft.Authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa"
       ],
       "deployment": {
         "properties": {

--- a/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-Backup/azurepolicy.rules.json
+++ b/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-Backup/azurepolicy.rules.json
@@ -1,0 +1,175 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.RecoveryServices/vaults"
+      },
+      {
+        "field": "location",
+        "in": "[parameters('AzureRegions')]"
+      }
+    ]
+  },
+  "then": {
+    "effect": "deployIfNotExists",
+    "details": {
+      "type": "Microsoft.Insights/diagnosticSettings",
+      "existenceCondition": {
+        "allOf": [
+          {
+            "count": {
+              "field": "Microsoft.Insights/diagnosticSettings/logs[*]",
+              "where": {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Insights/diagnosticSettings/logs[*].Category",
+                    "in": [
+                      "CoreAzureBackup",
+                      "AddonAzureBackupJobs",
+                      "AddonAzureBackupAlerts",
+                      "AddonAzureBackupPolicy",
+                      "AddonAzureBackupStorage",
+                      "AddonAzureBackupProtectedInstance"
+                    ]
+                  },
+                  {
+                    "field": "Microsoft.Insights/diagnosticSettings/logs[*].Enabled",
+                    "equals": "True"
+                  }
+                ]
+              }
+            },
+            "Equals": 6
+          },
+          {
+            "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
+            "matchInsensitively": "[parameters('logAnalytics')]"
+          },
+          {
+            "field": "Microsoft.Insights/diagnosticSettings/logAnalyticsDestinationType",
+            "Equals": "Dedicated"
+          }
+        ]
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293",
+        "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "template": {
+            "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "diagnosticsSettingNameToUse": {
+                "type": "string"
+              },
+              "resourceName": {
+                "type": "string"
+              },
+              "logAnalytics": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              },
+              "logsEnabled": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "metricsEnabled": {
+                "type": "string"
+              },
+             
+              "profileName": {
+                "type": "string"
+              }
+            },
+            "variables": {},
+            "resources": [
+              {
+                "type": "Microsoft.RecoveryServices/vaults/providers/diagnosticSettings",
+                "apiVersion": "2017-05-01-preview",
+                "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]",
+                "location": "[parameters('location')]",
+                "dependsOn": [],
+                "properties": {
+                  "workspaceId": "[parameters('logAnalytics')]",
+                  "logAnalyticsDestinationType": "Dedicated",
+                  "metrics": [ {
+                    "category": "AllMetrics",
+                    "enabled": "[parameters('metricsEnabled')]",
+                    "retentionPolicy": {
+                      "enabled": false,
+                      "days": 0
+                    }
+                  }],
+                  "logs": [
+                    {
+                      "category": "CoreAzureBackup",
+                      "enabled": "[parameters('logsEnabled')]"
+                    },
+                    {
+                      "category": "AddonAzureBackupJobs",
+                      "enabled": "[parameters('logsEnabled')]"
+                    },
+                    {
+                      "category": "AddonAzureBackupAlerts",
+                      "enabled": "[parameters('logsEnabled')]"
+                    },
+                    {
+                      "category": "AddonAzureBackupPolicy",
+                      "enabled": "[parameters('logsEnabled')]"
+                    },
+                    {
+                      "category": "AddonAzureBackupStorage",
+                      "enabled": "[parameters('logsEnabled')]"
+                    },
+                    {
+                      "category": "AddonAzureBackupProtectedInstance",
+                      "enabled": "[parameters('logsEnabled')]"
+                    }
+                  ]
+                }
+              }
+            ],
+            "outputs": {"policy": {
+              "type": "string",
+              "value": "[concat(parameters('logAnalytics'), 'configured for diagnostic logs for ', ': ', parameters('name'))]"
+            }}
+          },
+          "parameters": {
+            "diagnosticsSettingNameToUse": {
+              "value": "[parameters('diagnosticsSettingNameToUse')]"
+            },
+            "logAnalytics": {
+              "value": "[parameters('logAnalytics')]"
+            },
+            "resourceName": {
+              "value": "[field('name')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            },
+            "name": {
+              "value": "[field('name')]"
+            },
+            "metricsEnabled": {
+              "value": "[parameters('metricsEnabled')]"
+            },
+            "logsEnabled": {
+              "value": "[parameters('logsEnabled')]"
+            },
+            "profileName": {
+              "value": "[parameters('profileName')]"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-SiteRecovery/azurepolicy.config.json
+++ b/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-SiteRecovery/azurepolicy.config.json
@@ -1,0 +1,4 @@
+{
+    "name": "Deploy Diagnostic Settings for Recovery Vault for Site Recovery Events",
+    "mode": "all"
+}

--- a/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-SiteRecovery/azurepolicy.config.json
+++ b/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-SiteRecovery/azurepolicy.config.json
@@ -1,4 +1,4 @@
 {
     "name": "Deploy Diagnostic Settings for Recovery Vault for Site Recovery Events",
-    "mode": "all"
+    "mode": "indexed"
 }

--- a/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-SiteRecovery/azurepolicy.parameters.json
+++ b/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-SiteRecovery/azurepolicy.parameters.json
@@ -1,0 +1,57 @@
+{
+  "profileName": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Profile Name for Config",
+      "description": "The profile name Azure Diagnostics"
+    }
+  },
+  "logAnalytics": {
+    "type": "string",
+    "metadata": {
+      "displayName": "logAnalytics",
+      "description": "The target Log Analytics Workspace for Azure Diagnostics",
+      "strongType": "omsWorkspace"
+    }
+  },
+  "azureRegions": {
+    "type": "Array",
+    "metadata": {
+      "displayName": "Allowed Locations",
+      "description": "The list of locations that can be specified when deploying resources",
+      "strongType": "location"
+    }
+  },
+  "metricsEnabled": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Enable Metrics",
+      "description": "Enable Metrics - True or False"
+    },
+    "allowedValues": [
+      "True",
+      "False"
+    ],
+    "defaultValue": "False"
+  },
+  "logsEnabled": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Enable Logs",
+      "description": "Enable Logs - True or False"
+    },
+    "allowedValues": [
+      "True",
+      "False"
+    ],
+    "defaultValue": "True"
+  },
+  "diagnosticsSettingNameToUse": {
+    "type": "string",
+    "metadata": {
+      "displayName": "Setting name",
+      "description": "Name of the policy for the diagnostics settings."
+    },
+    "defaultValue": "setByPolicy-asr"
+  }
+}

--- a/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-SiteRecovery/azurepolicy.rules.json
+++ b/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-SiteRecovery/azurepolicy.rules.json
@@ -55,7 +55,7 @@
       },
       "roleDefinitionIds": [
         "/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293",
-        "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+        "/providers/Microsoft.Authorization/roleDefinitions/749f88d5-cbae-40b8-bcfc-e573ddc772fa"
       ],
       "deployment": {
         "properties": {

--- a/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-SiteRecovery/azurepolicy.rules.json
+++ b/policy/custom/definitions/policy/LA-Microsoft.AzureRecoveryVault-SiteRecovery/azurepolicy.rules.json
@@ -1,0 +1,179 @@
+{
+  "if": {
+    "allOf": [
+      {
+        "field": "type",
+        "equals": "Microsoft.RecoveryServices/vaults"
+      },
+      {
+        "field": "location",
+        "in": "[parameters('AzureRegions')]"
+      }
+    ]
+  },
+  "then": {
+    "effect": "deployIfNotExists",
+    "details": {
+      "type": "Microsoft.Insights/diagnosticSettings",
+      "existenceCondition": {
+        "allOf": [
+          {
+            "count": {
+              "field": "Microsoft.Insights/diagnosticSettings/logs[*]",
+              "where": {
+                "allOf": [
+                  {
+                    "field": "Microsoft.Insights/diagnosticSettings/logs[*].Category",
+                    "in": [
+                      "AzureSiteRecoveryJobs",
+                      "AzureSiteRecoveryEvents",
+                      "AzureSiteRecoveryReplicatedItems",
+                      "AzureSiteRecoveryReplicationStats",
+                      "AzureSiteRecoveryRecoveryPoints",
+                      "AzureSiteRecoveryReplicationDataUploadRate",
+                      "AzureSiteRecoveryProtectedDiskDataChurn"
+                    ]
+                  },
+                  {
+                    "field": "Microsoft.Insights/diagnosticSettings/logs[*].Enabled",
+                    "equals": "True"
+                  }
+                ]
+              }
+            },
+            "Equals": 7
+          },
+          {
+            "field": "Microsoft.Insights/diagnosticSettings/workspaceId",
+            "matchInsensitively": "[parameters('logAnalytics')]"
+          },
+          {
+            "field": "Microsoft.Insights/diagnosticSettings/logAnalyticsDestinationType",
+            "notEquals": "Dedicated"
+          }
+        ]
+      },
+      "roleDefinitionIds": [
+        "/providers/Microsoft.Authorization/roleDefinitions/92aaf0da-9dab-42b6-94a3-d43ce8d16293",
+        "/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c"
+      ],
+      "deployment": {
+        "properties": {
+          "mode": "incremental",
+          "template": {
+            "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+            "contentVersion": "1.0.0.0",
+            "parameters": {
+              "diagnosticsSettingNameToUse": {
+                "type": "string"
+              },
+              "resourceName": {
+                "type": "string"
+              },
+              "logAnalytics": {
+                "type": "string"
+              },
+              "location": {
+                "type": "string"
+              },
+              "logsEnabled": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "metricsEnabled": {
+                "type": "string"
+              },
+             
+              "profileName": {
+                "type": "string"
+              }
+            },
+            "variables": {},
+            "resources": [
+              {
+                "type": "Microsoft.RecoveryServices/vaults/providers/diagnosticSettings",
+                "apiVersion": "2017-05-01-preview",
+                "name": "[concat(parameters('resourceName'), '/', 'Microsoft.Insights/', parameters('profileName'))]",
+                "location": "[parameters('location')]",
+                "dependsOn": [],
+                "properties": {
+                  "workspaceId": "[parameters('logAnalytics')]",
+                  "metrics": [ {
+                    "category": "AllMetrics",
+                    "enabled": "[parameters('metricsEnabled')]",
+                    "retentionPolicy": {
+                      "enabled": false,
+                      "days": 0
+                    }
+                  }],
+                  "logs": [
+                    {
+                      "category": "AzureSiteRecoveryJobs",
+                      "enabled":"[parameters('logsEnabled')]"
+                    },
+                    {
+                      "category": "AzureSiteRecoveryEvents",
+                      "enabled": "[parameters('logsEnabled')]"
+                    },
+                    {
+                      "category": "AzureSiteRecoveryReplicatedItems",
+                      "enabled":"[parameters('logsEnabled')]"
+                    },
+                    {
+                      "category": "AzureSiteRecoveryReplicationStats",
+                      "enabled": "[parameters('logsEnabled')]"
+                    },
+                    {
+                      "category": "AzureSiteRecoveryRecoveryPoints",
+                      "enabled": "[parameters('logsEnabled')]"
+                    },
+                    {
+                      "category": "AzureSiteRecoveryReplicationDataUploadRate",
+                      "enabled": "[parameters('logsEnabled')]"
+                    },
+                    {
+                      "category": "AzureSiteRecoveryProtectedDiskDataChurn",
+                      "enabled": "[parameters('logsEnabled')]"
+                    }
+                  ]
+                }
+              }
+            ],
+            "outputs": {"policy": {
+              "type": "string",
+              "value": "[concat(parameters('logAnalytics'), 'configured for diagnostic logs for ', ': ', parameters('name'))]"
+            }}
+          },
+          "parameters": {
+            "diagnosticsSettingNameToUse": {
+              "value": "[parameters('diagnosticsSettingNameToUse')]"
+            },
+            "logAnalytics": {
+              "value": "[parameters('logAnalytics')]"
+            },
+            "resourceName": {
+              "value": "[field('name')]"
+            },
+            "location": {
+              "value": "[field('location')]"
+            },
+            "name": {
+              "value": "[field('name')]"
+            },
+            "metricsEnabled": {
+              "value": "[parameters('metricsEnabled')]"
+            },
+            "logsEnabled": {
+              "value": "[parameters('logsEnabled')]"
+            },
+            "profileName": {
+              "value": "[parameters('profileName')]"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/policy/custom/definitions/policyset/LogAnalytics.bicep
+++ b/policy/custom/definitions/policyset/LogAnalytics.bicep
@@ -73,7 +73,7 @@ resource policyset_name 'Microsoft.Authorization/policySetDefinitions@2020-03-01
           'Microsoft.DBforPostgreSQL/servers'
           'Microsoft.PowerBIDedicated/capacities'
           'Microsoft.Network/publicIPAddresses'
-          'Microsoft.RecoveryServices/vaults'
+         'Microsoft.RecoveryServices/vaults'
           'Microsoft.Cache/redis'
           'Microsoft.Relay/namespaces'
           'Microsoft.Search/searchServices'
@@ -284,18 +284,6 @@ resource policyset_name 'Microsoft.Authorization/policySetDefinitions@2020-03-01
         ]
         policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/237e0f7e-b0e8-4ec4-ad46-8c12cb66d673'
         policyDefinitionReferenceId: toLower(replace('Deploy Diagnostic Settings for Stream Analytics to Log Analytics workspace', ' ', '-'))
-        parameters: {
-          logAnalytics: {
-            value: '[parameters(\'logAnalytics\')]'
-          }
-        }
-      }
-      {
-        groupNames: [
-          'BUILTIN'
-        ]
-        policyDefinitionId: '/providers/Microsoft.Authorization/policyDefinitions/c717fb0c-d118-4c43-ab3d-ece30ac81fb3'
-        policyDefinitionReferenceId: toLower(replace('Deploy Diagnostic Settings for Recovery Services Vault to Log Analytics workspace for resource specific categories', ' ', '-'))
         parameters: {
           logAnalytics: {
             value: '[parameters(\'logAnalytics\')]'
@@ -776,7 +764,7 @@ resource policyset_name 'Microsoft.Authorization/policySetDefinitions@2020-03-01
           'CUSTOM'
         ]
         policyDefinitionId: extensionResourceId(customPolicyDefinitionMgScope, 'Microsoft.Authorization/policyDefinitions', 'LA-Microsoft.AzureRecoveryVault-SiteRecovery')
-        policyDefinitionReferenceId: toLower(replace('Deploy Diagnostic Settings for Site Recovery Event to Log Analytics Workspace', ' ', '-'))
+        policyDefinitionReferenceId: toLower(replace('Deploy Diagnostic Settings for Site Recovery Events to Log Analytics Workspace', ' ', '-'))
         parameters: {
           logAnalytics: {
             value: '[parameters(\'logAnalytics\')]'

--- a/policy/custom/definitions/policyset/LogAnalytics.bicep
+++ b/policy/custom/definitions/policyset/LogAnalytics.bicep
@@ -771,6 +771,48 @@ resource policyset_name 'Microsoft.Authorization/policySetDefinitions@2020-03-01
           }
         }
       }
+      {
+        groupNames: [
+          'CUSTOM'
+        ]
+        policyDefinitionId: extensionResourceId(customPolicyDefinitionMgScope, 'Microsoft.Authorization/policyDefinitions', 'LA-Microsoft.AzureRecoveryVault-SiteRecovery')
+        policyDefinitionReferenceId: toLower(replace('Deploy Diagnostic Settings for Site Recovery Event to Log Analytics Workspace', ' ', '-'))
+        parameters: {
+          logAnalytics: {
+            value: '[parameters(\'logAnalytics\')]'
+          }
+          profileName: {
+            value: 'setByPolicy-asr'
+          }
+          azureRegions: {
+            value: [
+              'canadacentral'
+              'canadaeast'
+            ]
+          }
+        }
+      }
+      {
+        groupNames: [
+          'CUSTOM'
+        ]
+        policyDefinitionId: extensionResourceId(customPolicyDefinitionMgScope, 'Microsoft.Authorization/policyDefinitions', 'LA-Microsoft.AzureRecoveryVault-Backup')
+        policyDefinitionReferenceId: toLower(replace('Deploy Diagnostic Settings for Azure Backup Events to Log Analytics Workspace', ' ', '-'))
+        parameters: {
+          logAnalytics: {
+            value: '[parameters(\'logAnalytics\')]'
+          }
+          profileName: {
+            value: 'setByPolicy-backup'
+          }
+          azureRegions: {
+            value: [
+              'canadacentral'
+              'canadaeast'
+            ]
+          }
+        }
+      }
     ]
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Added custom Azure Policy to the Custom - Log Analytics for Azure Services Policy Sets, this include

1. Deploy Diagnostic Settings for Recovery Vault for Site Recovery Events policy
2. Deploy Diagnostic Settings for Recovery Vault for Azure Backup Events policy
3. Updated the LogAnalytics.bicep file to include entry for the above policies

## This PR fixes/adds/changes/removes

1. Correlation of Site Recovery events within a Recovery Vault to the Log Analytics Workspace using the "Azure Diagnostics destination table"
2.. Correlation of Azure Backup events within a Recovery Vault to the Log Analytics Workspace using the "Resource specific destination table"


### Breaking Changes

1. N/A


## Testing Evidence

- Deploy and ran the policy pipeline
- Deploy a new recovery vault and validate the two separate diagnostic logging were available i.e. one for backup events and the other for site recovery events
-
![image](https://user-images.githubusercontent.com/953763/146594677-963c7103-a8eb-4c7e-a757-280cffd8b9ca.png)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
