### PR TITLE
Removed 'privatelink.monitor.azure.com' from Private DNS Zones

### DIFF
--- a/azresources/network/private-dns-zone-privatelinks.bicep
+++ b/azresources/network/private-dns-zone-privatelinks.bicep
@@ -59,7 +59,7 @@ param privateDnsZones array = [
   'privatelink.api.azureml.ms'
   'privatelink.notebooks.azure.net'
   'privatelink.service.signalr.net'
-  'privatelink.monitor.azure.com'
+//  'privatelink.monitor.azure.com'
   'privatelink.oms.opinsights.azure.com'
   'privatelink.ods.opinsights.azure.com'
   'privatelink.agentsvc.azure-automation.net'


### PR DESCRIPTION
Fixes #148 

**Background:**

The Azure Monitor Private DNS zone was removed because Azure Monitor uses some shared endpoints (meaning endpoints that are not resource-specific), setting up a Private Link even for a single resource changes the DNS configuration affecting traffic to all resources. In other words, traffic to all workspaces or components are affected by a single Private Link setup.

If AMPLS (Azure Monitor Private Link Scope) and PE (Private Endpoint) are not configured it affects access to Azure Monitor resources from the VNet linked to the Private DNS zone.

https://docs.microsoft.com/en-us/azure/azure-monitor/logs/private-link-security
https://docs.microsoft.com/en-us/azure/azure-monitor/logs/private-link-design#plan-by-network-topology

Due to the fact it requires additional steps and considerations to connect privately to Azure Monitor, the Azure Private DNS zone configuration should be created separately based on the decisions made.

https://docs.microsoft.com/en-us/azure/azure-monitor/logs/private-link-configure