### PR TITLE
docs(networking): don't have to comment variables

### DIFF
--- a/docs/onboarding/azure-devops-pipelines.md
+++ b/docs/onboarding/azure-devops-pipelines.md
@@ -415,7 +415,11 @@ In order to configure audit stream for Azure Monitor, identify the following inf
      1. [Hub Networking with Azure Firewall](../../docs/archetypes/hubnetwork-azfw.md)
      2. [Hub Networking with Fortinet Firewall (NVA)](../../docs/archetypes/hubnetwork-nva-fortigate.md)
 
-    Depending on the preference, you may delete/comment the configuration that is not required. For example, when deploying option 1 (Azure Firewall) - remove/comment section of the configuration file titled "Hub Networking with Fortinet Firewalls".
+    Depending on the preference, you may optionally delete/comment the configuration that is not required. For example, when deploying option 1 (Azure Firewall) - remove/comment section of the configuration file titled "Hub Networking with Fortinet Firewalls".
+
+    > Note: Even deleting or commenting out the variables that are not required, either for the **Hub Networking with Azure Firewall** or the **Hub Networking with Fortinet Firewall (NVA)**
+    is optional since the deployment will be based on the pipeline you configure anyway. So if you configured the **platform-connectivity-hub-azfw-policy-ci** and the **platform-connectivity-hub-azfw-ci** pipelines,
+    only the _Azure Firewall_ option will be deployed, not the _NVA_ option.
 
     * Update **var-hubnetwork-managementGroupId** with the networking management group.  This is based on the prefix defined in `var-topLevelManagementGroupName`.  For example, if `var-topLevelManagementGroupName` is set to `contoso`, then `var-hubnetwork-managementGroupId` will be `contosoPlatformConnectivity`.
     


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Add a note to indicate that commenting out or deleting hub network configuration variables in `./config/variables/<devops-org-name>-<branch-name>.yml` isn't necessary.

## This PR fixes/adds/changes/removes

1. **#183** 

### Breaking Changes

1. *None*

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

![step-7-configure-hub-networking](https://user-images.githubusercontent.com/15109536/155863150-3aac7b0f-fff2-4a72-9610-57c4fca7975f.jpg)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
