### PR TITLE
Pass-thru secure strings

### DIFF
--- a/scripts/deployments/Functions/HubNetworkWithNVA.ps1
+++ b/scripts/deployments/Functions/HubNetworkWithNVA.ps1
@@ -29,10 +29,10 @@ function Set-HubNetwork-With-NVA {
     [String]$LogAnalyticsWorkspaceResourceId,
 
     [Parameter(Mandatory = $false)]
-    [String]$NvaUsername = $null,
+    [SecureString]$NvaUsername = $null,
 
     [Parameter(Mandatory = $false)]
-    [String]$NvaPassword = $null
+    [SecureString]$NvaPassword = $null
   )
 
   Set-AzContext -Subscription $SubscriptionId
@@ -67,7 +67,7 @@ function Set-HubNetwork-With-NVA {
     Write-Output "NVA username is provided.  Setting NVA username in configuration."
     $NvaUsernameElement = @{
       fwUsername = @{
-        value = $NvaUsername
+        value = ($NvaUsername | ConvertFrom-SecureString -AsPlainText)
       }
     }
     $Configuration.parameters | Add-Member $NvaUsernameElement -Force
@@ -77,7 +77,7 @@ function Set-HubNetwork-With-NVA {
     Write-Output "NVA password is provided.  Setting NVA password in configuration."
     $NvaPasswordElement = @{
       fwPassword = @{
-        value = $NvaPassword
+        value = ($NvaPassword | ConvertFrom-SecureString -AsPlainText)
       }
     }
     $Configuration.parameters | Add-Member $NvaPasswordElement -Force

--- a/scripts/deployments/RunWorkflows.ps1
+++ b/scripts/deployments/RunWorkflows.ps1
@@ -259,8 +259,8 @@ if ($DeployHubNetworkWithNVA) {
     -SubscriptionId $Context.Variables['var-hubnetwork-subscriptionId'] `
     -ConfigurationFilePath "$($Context.NetworkingDirectory)/$($Context.Variables['var-hubnetwork-nva-configurationFileName'])" `
     -LogAnalyticsWorkspaceResourceId $LoggingConfiguration.LogAnalyticsWorkspaceResourceId `
-    -NvaUsername (ConvertFrom-SecureString -SecureString $NvaUsername -AsPlainText) `
-    -NvaPassword (ConvertFrom-SecureString -SecureString $NvaPassword -AsPlainText)
+    -NvaUsername $NvaUsername `
+    -NvaPassword $NvaPassword
 }
 
 # Hub Networking with Azure Firewall


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Ensure `SecureString` parameters are passed through for Hub Networking + NVA scenario.

## This PR fixes/adds/changes/removes

Fixes #280 

### Breaking Changes

None

## Testing Evidence

**Hub Networking with NVA**
![image](https://user-images.githubusercontent.com/16688027/167516720-7bcd679a-b1a7-4362-891a-751dde47eba8.png)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
