### PR TITLE
Ensure multiple subscriptions can be moved to a management in parallel

### DIFF
--- a/.github/workflows/6-subscriptions.yml
+++ b/.github/workflows/6-subscriptions.yml
@@ -14,7 +14,7 @@ on:
     inputs:
       subscriptionIds:
         type: string
-        description: Subscription ID(s) (optional), e.g. "abcd", "1234"
+        description: Subscription ID(s), e.g. "abcd", "1234"
         required: true
       environmentName:
         type: string


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

- Generate deployment name for subscription move based on subscription id and location.  This ensure uniqueness when multiple subscriptions are moved in parallel.  Name is limited to 63 characters.

- Fix input description for Subscription workflow. 
 
## This PR fixes/adds/changes/removes

Fixes #287 

### Breaking Changes

None

## Testing Evidence

**GitHub Action Workflow**
![image](https://user-images.githubusercontent.com/16688027/167714251-6d79157c-e817-404b-a5d0-a36422ad590d.png)

**Deployment names at `DevTest` management group scope when moving subscriptions**
> ![image](https://user-images.githubusercontent.com/16688027/167714146-59333108-f7b3-4a57-bff1-c9a79728966b.png)



## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
