### PR TITLE
Separate Azure Firewall Policy deployment switch & unique telemetry tracking for policy assignments

### DIFF
--- a/.github/workflows/0-everything.yml
+++ b/.github/workflows/0-everything.yml
@@ -163,7 +163,8 @@ jobs:
       if: github.event.inputs.hubNetworkType == 'HubNetworkWithAzureFirewall'
       run: |
         ./RunWorkflows.ps1 `
-          -Deploy${{github.event.inputs.hubNetworkType}} `
+          -DeployAzureFirewallPolicy `
+          -DeployHubNetworkWithAzureFirewall `
           -EnvironmentName '${{github.event.inputs.environmentName}}' `
           -LoginServicePrincipalJson (ConvertTo-SecureString -String '${{secrets.ALZ_CREDENTIALS}}' -AsPlainText -Force) `
           -GitHubRepo ${env:GITHUB_REPOSITORY} `
@@ -173,7 +174,7 @@ jobs:
       if: github.event.inputs.hubNetworkType == 'HubNetworkWithNVA'
       run: |
         ./RunWorkflows.ps1 `
-          -Deploy${{github.event.inputs.hubNetworkType}} `
+          -DeployHubNetworkWithNVA `
           -EnvironmentName '${{github.event.inputs.environmentName}}' `
           -LoginServicePrincipalJson (ConvertTo-SecureString -String '${{secrets.ALZ_CREDENTIALS}}' -AsPlainText -Force) `
           -GitHubRepo ${env:GITHUB_REPOSITORY} `

--- a/.github/workflows/0-everything.yml
+++ b/.github/workflows/0-everything.yml
@@ -159,11 +159,20 @@ jobs:
         Install-Module Az -Force
         Install-Module powershell-yaml -Force
 
-    - name: Deploy Hub Network with Azure Firewall
+    - name: Deploy Azure Firewall Policy
       if: github.event.inputs.hubNetworkType == 'HubNetworkWithAzureFirewall'
       run: |
         ./RunWorkflows.ps1 `
           -DeployAzureFirewallPolicy `
+          -EnvironmentName '${{github.event.inputs.environmentName}}' `
+          -LoginServicePrincipalJson (ConvertTo-SecureString -String '${{secrets.ALZ_CREDENTIALS}}' -AsPlainText -Force) `
+          -GitHubRepo ${env:GITHUB_REPOSITORY} `
+          -GitHubRef ${env:GITHUB_REF}
+
+    - name: Deploy Hub Network with Azure Firewall
+      if: github.event.inputs.hubNetworkType == 'HubNetworkWithAzureFirewall'
+      run: |
+        ./RunWorkflows.ps1 `
           -DeployHubNetworkWithAzureFirewall `
           -EnvironmentName '${{github.event.inputs.environmentName}}' `
           -LoginServicePrincipalJson (ConvertTo-SecureString -String '${{secrets.ALZ_CREDENTIALS}}' -AsPlainText -Force) `

--- a/.github/workflows/5-azure-firewall-policy.yml
+++ b/.github/workflows/5-azure-firewall-policy.yml
@@ -1,0 +1,46 @@
+# ----------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+#
+# THIS CODE AND INFORMATION ARE PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND, 
+# EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
+# OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
+# ----------------------------------------------------------------------------------
+
+name: 5 - Azure Firewall Policy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environmentName:
+        type: string
+        description: Environment name (optional), e.g. CanadaESLZ-main
+        required: false
+
+defaults:
+  run:
+    shell: pwsh
+    working-directory: scripts/deployments
+
+jobs:
+  azure-firewall-policy:
+    name: Azure Firewall Policy
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure PowerShell modules
+      run: |
+        Install-Module Az -Force
+        Install-Module powershell-yaml -Force
+
+    - name: Deploy Azure Firewall Policy
+      run: |
+        ./RunWorkflows.ps1 `
+          -DeployAzureFirewallPolicy `
+          -EnvironmentName '${{github.event.inputs.environmentName}}' `
+          -LoginServicePrincipalJson (ConvertTo-SecureString -String '${{secrets.ALZ_CREDENTIALS}}' -AsPlainText -Force) `
+          -GitHubRepo ${env:GITHUB_REPOSITORY} `
+          -GitHubRef ${env:GITHUB_REF}

--- a/.github/workflows/5-azure-firewall-policy.yml
+++ b/.github/workflows/5-azure-firewall-policy.yml
@@ -16,7 +16,7 @@ on:
         type: string
         description: Environment name (optional), e.g. CanadaESLZ-main
         required: false
-  pull_request:
+  push:
 
 defaults:
   run:

--- a/.github/workflows/5-azure-firewall-policy.yml
+++ b/.github/workflows/5-azure-firewall-policy.yml
@@ -16,6 +16,7 @@ on:
         type: string
         description: Environment name (optional), e.g. CanadaESLZ-main
         required: false
+  pull_request:
 
 defaults:
   run:

--- a/.github/workflows/5-azure-firewall-policy.yml
+++ b/.github/workflows/5-azure-firewall-policy.yml
@@ -6,7 +6,7 @@
 # EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES 
 # OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 # ----------------------------------------------------------------------------------
-
+# Test
 name: 5 - Azure Firewall Policy
 
 on:

--- a/.github/workflows/5-azure-firewall-policy.yml
+++ b/.github/workflows/5-azure-firewall-policy.yml
@@ -16,7 +16,6 @@ on:
         type: string
         description: Environment name (optional), e.g. CanadaESLZ-main
         required: false
-  push:
 
 defaults:
   run:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,6 +19,7 @@ The following workflows are present in the `.github/workflows` repository folder
 | 2 | Roles | `2-roles.yml`
 | 3 | Logging | `3-logging.yml`
 | 4 | Policy | `policy.yml`
+| 5 | Azure Firewall Policy (required for Hub Networking with Azure Firewall) | `5-azure-firewall-policy.yml`
 | 5 | Hub Networking with Azure Firewall | `5-hub-network-with-azure-firewall.yml`
 | 5 | Hub Networking with NVA | `5-hub-network-with-nva.yml`
 | 6 | Subscriptions | `6-subscriptions.yml`

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -18,7 +18,7 @@ The following workflows are present in the `.github/workflows` repository folder
 | 1 | Management Groups | `1-management-groups.yml`
 | 2 | Roles | `2-roles.yml`
 | 3 | Logging | `3-logging.yml`
-| 4 | Policy | `policy.yml`
+| 4 | Policy | `4-policy.yml`
 | 5 | Azure Firewall Policy (required for Hub Networking with Azure Firewall) | `5-azure-firewall-policy.yml`
 | 5 | Hub Networking with Azure Firewall | `5-hub-network-with-azure-firewall.yml`
 | 5 | Hub Networking with NVA | `5-hub-network-with-nva.yml`

--- a/config/networking/CanadaESLZ-main/hub-azfw/hub-network.parameters.json
+++ b/config/networking/CanadaESLZ-main/hub-azfw/hub-network.parameters.json
@@ -85,7 +85,7 @@
     },
     "ddosStandard": {
       "value": {
-        "enabled": true,
+        "enabled": false,
         "resourceGroupName": "pubsec-ddos-rg",
         "planName": "ddos-plan"
       }

--- a/config/networking/CanadaESLZ-main/hub-azfw/hub-network.parameters.json
+++ b/config/networking/CanadaESLZ-main/hub-azfw/hub-network.parameters.json
@@ -85,7 +85,7 @@
     },
     "ddosStandard": {
       "value": {
-        "enabled": false,
+        "enabled": true,
         "resourceGroupName": "pubsec-ddos-rg",
         "planName": "ddos-plan"
       }

--- a/policy/builtin/assignments/asb.bicep
+++ b/policy/builtin/assignments/asb.bicep
@@ -32,7 +32,7 @@ var policyScopedId = resourceId('Microsoft.Authorization/policySetDefinitions', 
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-asb'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/builtin/assignments/cis-msft-130.bicep
+++ b/policy/builtin/assignments/cis-msft-130.bicep
@@ -44,7 +44,7 @@ var policyScopedId = resourceId('Microsoft.Authorization/policySetDefinitions', 
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-cis-msft-130'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/builtin/assignments/fedramp-moderate.bicep
+++ b/policy/builtin/assignments/fedramp-moderate.bicep
@@ -35,7 +35,7 @@ var policyScopedId = resourceId('Microsoft.Authorization/policySetDefinitions', 
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-fedramp-m'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/builtin/assignments/hitrust-hipaa.bicep
+++ b/policy/builtin/assignments/hitrust-hipaa.bicep
@@ -47,7 +47,7 @@ var policyScopedId = resourceId('Microsoft.Authorization/policySetDefinitions', 
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-hitrust-hipaa'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/builtin/assignments/location.bicep
+++ b/policy/builtin/assignments/location.bicep
@@ -31,7 +31,7 @@ var scope = tenantResourceId('Microsoft.Management/managementGroups', policyAssi
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-location'
 }
 
 resource rgLocationAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/builtin/assignments/nist80053r4.bicep
+++ b/policy/builtin/assignments/nist80053r4.bicep
@@ -41,7 +41,7 @@ var policyScopedId = resourceId('Microsoft.Authorization/policySetDefinitions', 
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-nist-80053-r4'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/builtin/assignments/nist80053r5.bicep
+++ b/policy/builtin/assignments/nist80053r5.bicep
@@ -35,7 +35,7 @@ var policyScopedId = resourceId('Microsoft.Authorization/policySetDefinitions', 
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-nist-80053-r5'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/builtin/assignments/pbmm.bicep
+++ b/policy/builtin/assignments/pbmm.bicep
@@ -41,7 +41,7 @@ var policyScopedId = resourceId('Microsoft.Authorization/policySetDefinitions', 
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-pbmm'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/custom/assignments/AKS.bicep
+++ b/policy/custom/assignments/AKS.bicep
@@ -35,7 +35,7 @@ var policyScopedId = '/providers/Microsoft.Management/managementGroups/${policyD
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-aks'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/custom/assignments/DDoS.bicep
+++ b/policy/custom/assignments/DDoS.bicep
@@ -38,7 +38,7 @@ var policyScopedId = '/providers/Microsoft.Management/managementGroups/${policyD
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-ddos'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/custom/assignments/DNSPrivateEndpoints.bicep
+++ b/policy/custom/assignments/DNSPrivateEndpoints.bicep
@@ -41,7 +41,7 @@ var policyScopedId = '/providers/Microsoft.Management/managementGroups/${policyD
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-dns-pe'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/custom/assignments/DefenderForCloud.bicep
+++ b/policy/custom/assignments/DefenderForCloud.bicep
@@ -35,7 +35,7 @@ var policyScopedId = '/providers/Microsoft.Management/managementGroups/${policyD
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-mdfc'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/custom/assignments/LogAnalytics.bicep
+++ b/policy/custom/assignments/LogAnalytics.bicep
@@ -41,7 +41,7 @@ var policyScopedId = '/providers/Microsoft.Management/managementGroups/${policyD
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-logging'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/custom/assignments/Network.bicep
+++ b/policy/custom/assignments/Network.bicep
@@ -35,7 +35,7 @@ var policyScopedId = '/providers/Microsoft.Management/managementGroups/${policyD
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-network'
 }
 
 resource policySetAssignment 'Microsoft.Authorization/policyAssignments@2020-03-01' = {

--- a/policy/custom/assignments/Tags.bicep
+++ b/policy/custom/assignments/Tags.bicep
@@ -31,7 +31,7 @@ var scope = tenantResourceId('Microsoft.Management/managementGroups', policyAssi
 // Reference:  https://docs.microsoft.com/azure/marketplace/azure-partner-customer-usage-attribution
 var telemetry = json(loadTextContent('../../../config/telemetry.json'))
 module telemetryCustomerUsageAttribution '../../../azresources/telemetry/customer-usage-attribution-management-group.bicep' = if (telemetry.customerUsageAttribution.enabled) {
-  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}'
+  name: 'pid-${telemetry.customerUsageAttribution.modules.policy}-tags'
 }
 
 // Tags Inherited from Subscription to Resource Groups

--- a/scripts/deployments/Functions/HubNetworkWithAzureFirewall.ps1
+++ b/scripts/deployments/Functions/HubNetworkWithAzureFirewall.ps1
@@ -59,7 +59,8 @@ function Set-AzureFirewallPolicy {
     -Name "main-$Region" `
     -Location $Region `
     -TemplateFile "$($Context.WorkingDirectory)/landingzones/lz-platform-connectivity-hub-azfw/main-azfw-policy.bicep" `
-    -TemplateParameterFile $ConfigurationFilePath
+    -TemplateParameterFile $ConfigurationFilePath `
+    -Verbose
 }
 
 function Set-HubNetwork-With-AzureFirewall {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

#290 
- Add suffix to each policy assignment to create uniqueness across the deployments.  This ensures parallel jobs does not create a race condition.

#291
- Wrapper Azure Firewall Policy deployment in a separate switch (as it can be run independently from the Hub Networking).
- Update Everything workflow to deploy Azure Firewall Policy & Hub Networking with Azure Firewall as a step.


## This PR fixes/adds/changes/removes

Fixes #290
Fixes #291  

### Breaking Changes

None

## Testing Evidence

**Azure Firewall Policy workflow**
![image](https://user-images.githubusercontent.com/16688027/167865313-4f87cff6-82fb-45cb-89be-546ef8b876b6.png)

**Everything workflow - Azure Firewall Policy deployed as separate step**
![image](https://user-images.githubusercontent.com/16688027/167867563-9e8aaa3d-5309-4d53-be1a-26e6cbafa584.png)

**Telemetry deployments for Azure Policies have unique deployment names**
![image](https://user-images.githubusercontent.com/16688027/167865531-e5fceabf-3486-4ebf-afcd-09476269b717.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
