### PR TITLE
Disable metrics in diagnostic settings for AKS through Policy

### DIFF
--- a/policy/custom/definitions/policyset/LogAnalytics.bicep
+++ b/policy/custom/definitions/policyset/LogAnalytics.bicep
@@ -305,6 +305,9 @@ resource policyset_name 'Microsoft.Authorization/policySetDefinitions@2020-03-01
           logAnalytics: {
             value: '[parameters(\'logAnalytics\')]'
           }
+          AllMetrics: {
+            value: 'false'
+          }
         }
       }
       {

--- a/policy/custom/definitions/policyset/LogAnalytics.bicep
+++ b/policy/custom/definitions/policyset/LogAnalytics.bicep
@@ -306,7 +306,7 @@ resource policyset_name 'Microsoft.Authorization/policySetDefinitions@2020-03-01
             value: '[parameters(\'logAnalytics\')]'
           }
           AllMetrics: {
-            value: 'false'
+            value: 'False'
           }
         }
       }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Disable metrics from being configured through diagnostic settings.  This is an alignment to the rest of the log analytics policy definitions where we enable only logs by default.

## This PR fixes/adds/changes/removes

Fixes #294 

### Breaking Changes

None

## Testing Evidence

**When metrics turned on by default**
> ![image](https://user-images.githubusercontent.com/16688027/168469245-974f1b84-038c-4392-89e6-bb6b7da80a4f.png)
> ![image](https://user-images.githubusercontent.com/16688027/168469279-bf4376a8-eee1-48e5-b80d-138399ffcce6.png)
> ![image](https://user-images.githubusercontent.com/16688027/168469300-1dc56188-fbe0-4384-b3a5-e939a213ba15.png)

**Policy Remediation**
> ![image](https://user-images.githubusercontent.com/16688027/168470199-2828ea13-42bb-4a71-8c67-b53769847bdd.png)

**When metrics turned off by default**
> ![image](https://user-images.githubusercontent.com/16688027/168470180-93044a18-f4bd-47c1-9e79-42febd68c8a8.png)
> ![image](https://user-images.githubusercontent.com/16688027/168470649-5fed927f-9cd3-433b-b00d-56d3e159eb3b.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
