### PR TITLE
GitHub Actions: disable fail fast for matrix deployments

### DIFF
--- a/.github/workflows/0-everything.yml
+++ b/.github/workflows/0-everything.yml
@@ -123,6 +123,7 @@ jobs:
         policyType:
           - DeployBuiltInPolicy
           - DeployCustomPolicy
+      fail-fast: false
 
     steps:
     - name: Checkout
@@ -227,6 +228,7 @@ jobs:
 
     strategy:
       matrix: ${{fromJSON(needs.SubscriptionMatrix.outputs.matrix)}}
+      fail-fast: false
 
     steps:
     - name: Checkout

--- a/.github/workflows/4-policy.yml
+++ b/.github/workflows/4-policy.yml
@@ -31,6 +31,7 @@ jobs:
         policyType:
           - DeployBuiltInPolicy
           - DeployCustomPolicy
+      fail-fast: false
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/6-subscriptions.yml
+++ b/.github/workflows/6-subscriptions.yml
@@ -62,6 +62,7 @@ jobs:
 
     strategy:
       matrix: ${{fromJSON(needs.SubscriptionMatrix.outputs.matrix)}}
+      fail-fast: false
 
     steps:
     - name: Checkout


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Disabling fail fast for matrix deployments in Policy & Subscription deployments.

## This PR fixes/adds/changes/removes

Fixes #296 

### Breaking Changes

None

## Testing Evidence

**Everything workflow - ensure successful run**
> ![image](https://user-images.githubusercontent.com/16688027/168475789-2fe4dd39-ab9d-4731-be8e-1a3c5c259060.png)

**Policy workflow - ensure successful run**
> ![image](https://user-images.githubusercontent.com/16688027/168476327-9239e672-0b76-485c-9268-5fa12f3599e2.png)

**Subscription workflow - ensure successful run**
> ![image](https://user-images.githubusercontent.com/16688027/168476306-0b200c3a-6026-4a84-86e8-28801f2bb81d.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
