### PR TITLE
Update resource group names for Logging & Networking

### DIFF
--- a/config/logging/CanadaESLZ-main/logging.parameters.json
+++ b/config/logging/CanadaESLZ-main/logging.parameters.json
@@ -57,7 +57,7 @@
       }
     },
     "logAnalyticsResourceGroupName": {
-      "value": "pubsec-central-logging-rg"
+      "value": "pubsec-central-logging"
     },
     "logAnalyticsWorkspaceName": {
       "value": "log-analytics-workspace"

--- a/config/networking/CanadaESLZ-main/hub-azfw-policy/azure-firewall-policy.parameters.json
+++ b/config/networking/CanadaESLZ-main/hub-azfw-policy/azure-firewall-policy.parameters.json
@@ -13,7 +13,7 @@
       }
     },
     "resourceGroupName": {
-      "value": "pubsec-azure-firewall-policy-rg"
+      "value": "pubsec-azure-firewall-policy"
     },
     "policyName": {
       "value": "pubsecAzureFirewallPolicy"

--- a/config/networking/CanadaESLZ-main/hub-azfw/hub-network.parameters.json
+++ b/config/networking/CanadaESLZ-main/hub-azfw/hub-network.parameters.json
@@ -59,26 +59,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -146,7 +146,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/config/networking/CanadaESLZ-main/hub-nva/hub-network.parameters.json
+++ b/config/networking/CanadaESLZ-main/hub-nva/hub-network.parameters.json
@@ -59,26 +59,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -146,7 +146,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/config/subscriptions/CanadaESLZ-main/pubsec/LandingZones/DevTest/4f9f8765-911a-4a6d-af60-4bc0473268c0_generic-subscription_canadacentral.json
+++ b/config/subscriptions/CanadaESLZ-main/pubsec/LandingZones/DevTest/4f9f8765-911a-4a6d-af60-4bc0473268c0_generic-subscription_canadacentral.json
@@ -87,7 +87,7 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4"

--- a/config/subscriptions/CanadaESLZ-main/pubsec/LandingZones/DevTest/82f7705e-3386-427b-95b7-cbed91ab29a7_healthcare_canadacentral.json
+++ b/config/subscriptions/CanadaESLZ-main/pubsec/LandingZones/DevTest/82f7705e-3386-427b-95b7-cbed91ab29a7_healthcare_canadacentral.json
@@ -104,13 +104,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/config/subscriptions/CanadaESLZ-main/pubsec/LandingZones/DevTest/8c6e48a4-4c73-4a1f-9f95-9447804f2c98_machinelearning_canadacentral.json
+++ b/config/subscriptions/CanadaESLZ-main/pubsec/LandingZones/DevTest/8c6e48a4-4c73-4a1f-9f95-9447804f2c98_machinelearning_canadacentral.json
@@ -122,13 +122,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/config/subscriptions/CanadaESLZ-main/pubsec/LandingZones/DevTest/ec6c5689-db04-4f1e-b76d-834a51dd0e27_machinelearning_canadacentral.json
+++ b/config/subscriptions/CanadaESLZ-main/pubsec/LandingZones/DevTest/ec6c5689-db04-4f1e-b76d-834a51dd0e27_machinelearning_canadacentral.json
@@ -126,13 +126,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/config/subscriptions/CanadaESLZ-main/pubsec/LandingZones/DevTest/f08c3057-1713-4a6f-b7e6-0df355b60c30_machinelearning_canadacentral.json
+++ b/config/subscriptions/CanadaESLZ-main/pubsec/LandingZones/DevTest/f08c3057-1713-4a6f-b7e6-0df355b60c30_machinelearning_canadacentral.json
@@ -126,13 +126,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/config/subscriptions/CanadaESLZ-main/pubsec/LandingZones/DevTest/f459218a-e8bb-49c9-b768-ee6828a144aa_machinelearning_canadacentral.json
+++ b/config/subscriptions/CanadaESLZ-main/pubsec/LandingZones/DevTest/f459218a-e8bb-49c9-b768-ee6828a144aa_machinelearning_canadacentral.json
@@ -127,13 +127,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/docs/archetypes/generic-subscription.md
+++ b/docs/archetypes/generic-subscription.md
@@ -137,7 +137,7 @@ This example configures:
             "value": "canadacentral"
         },
         "logAnalyticsWorkspaceResourceId": {
-            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
         },
         "serviceHealthAlerts": {
             "value": {
@@ -221,7 +221,7 @@ This example configures:
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4"

--- a/docs/archetypes/healthcare.md
+++ b/docs/archetypes/healthcare.md
@@ -371,7 +371,7 @@ This example configures:
             }
         },
         "logAnalyticsWorkspaceResourceId": {
-            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
         },
         "resourceGroups": {
             "value": {
@@ -415,13 +415,13 @@ This example configures:
             }},
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/docs/archetypes/hubnetwork-azfw.md
+++ b/docs/archetypes/hubnetwork-azfw.md
@@ -305,7 +305,7 @@ This example configures:
       }
     },
     "resourceGroupName": {
-      "value": "pubsec-azure-firewall-policy-rg"
+      "value": "pubsec-azure-firewall-policy"
     },
     "policyName": {
       "value": "pubsecAzureFirewallPolicy"
@@ -395,26 +395,26 @@ This example configures:
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": ["10.18.4.0/22"],
@@ -480,7 +480,7 @@ This example configures:
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/docs/archetypes/hubnetwork-nva-fortigate.md
+++ b/docs/archetypes/hubnetwork-nva-fortigate.md
@@ -310,7 +310,7 @@ This example configures:
   "contentVersion": "1.0.0.0",
   "parameters": {
     "logAnalyticsWorkspaceResourceId": {
-      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
     },
     "serviceHealthAlerts": {
       "value": {
@@ -375,26 +375,26 @@ This example configures:
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": ["10.18.4.0/22"],
@@ -460,7 +460,7 @@ This example configures:
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/docs/archetypes/logging.md
+++ b/docs/archetypes/logging.md
@@ -154,7 +154,7 @@ This example configures:
       }
     },
     "logAnalyticsResourceGroupName": {
-      "value": "pubsec-central-logging-rg"
+      "value": "pubsec-central-logging"
     },
     "logAnalyticsWorkspaceName": {
       "value": "log-analytics-workspace"

--- a/docs/archetypes/machinelearning.md
+++ b/docs/archetypes/machinelearning.md
@@ -376,7 +376,7 @@ This example configures:
       }
     },
     "logAnalyticsWorkspaceResourceId": {
-        "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+        "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
     },
     "resourceGroups": {
       "value": {
@@ -444,13 +444,13 @@ This example configures:
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/docs/onboarding/azure-devops-pipelines.md
+++ b/docs/onboarding/azure-devops-pipelines.md
@@ -576,7 +576,7 @@ This role assignment is used to grant users access to the logging subscription b
               }
             },
             "logAnalyticsResourceGroupName": {
-              "value": "pubsec-central-logging-rg"
+              "value": "pubsec-central-logging"
             },
             "logAnalyticsWorkspaceName": {
               "value": "log-analytics-workspace"
@@ -759,7 +759,7 @@ In order to configure audit stream for Azure Monitor, identify the following inf
                   }
                 },
                 "resourceGroupName": {
-                  "value": "pubsec-azure-firewall-policy-rg"
+                  "value": "pubsec-azure-firewall-policy"
                 },
                 "policyName": {
                   "value": "pubsecAzureFirewallPolicy"
@@ -878,26 +878,26 @@ In order to configure audit stream for Azure Monitor, identify the following inf
                 "privateDnsZones": {
                   "value": {
                     "enabled": true,
-                    "resourceGroupName": "pubsec-dns-rg"
+                    "resourceGroupName": "pubsec-dns"
                   }
                 },
                 "ddosStandard": {
                   "value": {
                     "enabled": false,
-                    "resourceGroupName": "pubsec-ddos-rg",
+                    "resourceGroupName": "pubsec-ddos",
                     "planName": "ddos-plan"
                   }
                 },
                 "publicAccessZone": {
                   "value": {
                     "enabled": true,
-                    "resourceGroupName": "pubsec-public-access-zone-rg"
+                    "resourceGroupName": "pubsec-public-access-zone"
                   }
                 },
                 "managementRestrictedZone": {
                   "value": {
                     "enabled": true,
-                    "resourceGroupName": "pubsec-management-restricted-zone-rg",
+                    "resourceGroupName": "pubsec-management-restricted-zone",
                     "network": {
                       "name": "management-restricted-vnet",
                       "addressPrefixes": ["10.18.4.0/22"],
@@ -963,7 +963,7 @@ In order to configure audit stream for Azure Monitor, identify the following inf
                 },
                 "hub": {
                   "value": {
-                    "resourceGroupName": "pubsec-hub-networking-rg",
+                    "resourceGroupName": "pubsec-hub-networking",
                     "bastion": {
                       "enabled": true,
                       "name": "bastion",
@@ -1137,26 +1137,26 @@ In order to configure audit stream for Azure Monitor, identify the following inf
                 "privateDnsZones": {
                   "value": {
                     "enabled": true,
-                    "resourceGroupName": "pubsec-dns-rg"
+                    "resourceGroupName": "pubsec-dns"
                   }
                 },
                 "ddosStandard": {
                   "value": {
                     "enabled": false,
-                    "resourceGroupName": "pubsec-ddos-rg",
+                    "resourceGroupName": "pubsec-ddos",
                     "planName": "ddos-plan"
                   }
                 },
                 "publicAccessZone": {
                   "value": {
                     "enabled": true,
-                    "resourceGroupName": "pubsec-public-access-zone-rg"
+                    "resourceGroupName": "pubsec-public-access-zone"
                   }
                 },
                 "managementRestrictedZone": {
                   "value": {
                     "enabled": true,
-                    "resourceGroupName": "pubsec-management-restricted-zone-rg",
+                    "resourceGroupName": "pubsec-management-restricted-zone",
                     "network": {
                       "name": "management-restricted-vnet",
                       "addressPrefixes": ["10.18.4.0/22"],
@@ -1222,7 +1222,7 @@ In order to configure audit stream for Azure Monitor, identify the following inf
                 },
                 "hub": {
                   "value": {
-                    "resourceGroupName": "pubsec-hub-networking-rg",
+                    "resourceGroupName": "pubsec-hub-networking",
                     "bastion": {
                       "enabled": true,
                       "name": "bastion",
@@ -1822,7 +1822,7 @@ Migration process:
               "value": < value from var-hubnetwork-resourceTags >
             },
             "resourceGroupName": {
-              "value": "< value from var-hubnetwork-azfw-rgPolicyName >"
+              "value": "< value from var-hubnetwork-azfwPolicyName >"
             },
             "policyName": {
               "value": "< value from var-hubnetwork-azfw-policyName >"
@@ -1866,26 +1866,26 @@ Migration process:
                 "privateDnsZones": {
                   "value": {
                     "enabled": < value from var-hubnetwork-deployPrivateDnsZones >,
-                    "resourceGroupName": "< value from var-hubnetwork-rgPrivateDnsZonesName >"
+                    "resourceGroupName": "< value from var-hubnetworkPrivateDnsZonesName >"
                   }
                 },
                 "ddosStandard": {
                   "value": {
                     "enabled": < value from var-hubnetwork-deployDdosStandard >,
-                    "resourceGroupName": "< value from var-hubnetwork-rgDdosName >",
+                    "resourceGroupName": "< value from var-hubnetworkDdosName >",
                     "planName": "< value from var-hubnetwork-ddosPlanName >"
                   }
                 },
                 "publicAccessZone": {
                   "value": {
                     "enabled": true,
-                    "resourceGroupName": "< value from var-hubnetwork-rgPazName >"
+                    "resourceGroupName": "< value from var-hubnetworkPazName >"
                   }
                 },
                 "managementRestrictedZone": {
                   "value": {
                     "enabled": true,
-                    "resourceGroupName": "< value from var-hubnetwork-rgMrzName >",
+                    "resourceGroupName": "< value from var-hubnetworkMrzName >",
                     "network": {
                       "name": "< value from var-hubnetwork-mrzVnetName >",
                       "addressPrefixes": [
@@ -1953,7 +1953,7 @@ Migration process:
                 },
                 "hub": {
                   "value": {
-                    "resourceGroupName": "< value from var-hubnetwork-azfw-rgHubName >",
+                    "resourceGroupName": "< value from var-hubnetwork-azfwHubName >",
                     "bastion": {
                       "enabled": true,
                       "name": "< value from var-hubnetwork-bastionName >",
@@ -2052,26 +2052,26 @@ Migration process:
             "privateDnsZones": {
               "value": {
                 "enabled": < value from var-hubnetwork-deployPrivateDnsZones >,
-                "resourceGroupName": "< value from var-hubnetwork-rgPrivateDnsZonesName >"
+                "resourceGroupName": "< value from var-hubnetworkPrivateDnsZonesName >"
               }
             },
             "ddosStandard": {
               "value": {
                 "enabled": < value from var-hubnetwork-deployDdosStandard >,
-                "resourceGroupName": "< value from var-hubnetwork-rgDdosName >",
+                "resourceGroupName": "< value from var-hubnetworkDdosName >",
                 "planName": "< value from var-hubnetwork-ddosPlanName >"
               }
             },
             "publicAccessZone": {
               "value": {
                 "enabled": true,
-                "resourceGroupName": "< value from var-hubnetwork-rgPazName >"
+                "resourceGroupName": "< value from var-hubnetworkPazName >"
               }
             },
             "managementRestrictedZone": {
               "value": {
                 "enabled": true,
-                "resourceGroupName": "< value from var-hubnetwork-rgMrzName >",
+                "resourceGroupName": "< value from var-hubnetworkMrzName >",
                 "network": {
                   "name": "< value from var-hubnetwork-mrzVnetName >",
                   "addressPrefixes": [
@@ -2139,7 +2139,7 @@ Migration process:
             },
             "hub": {
               "value": {
-                "resourceGroupName": "< value from var-hubnetwork-azfw-rgHubName >",
+                "resourceGroupName": "< value from var-hubnetwork-azfwHubName >",
                 "bastion": {
                   "enabled": true,
                   "name": "< value from var-hubnetwork-bastionName >",

--- a/docs/onboarding/azure-devops-pipelines.md
+++ b/docs/onboarding/azure-devops-pipelines.md
@@ -496,40 +496,19 @@ This role assignment is used to grant users access to the logging subscription b
           "parameters": {
             "serviceHealthAlerts": {
               "value": {
-                "resourceGroupName": "pubsec-service-health",
-                "incidentTypes": [
-                  "Incident",
-                  "Security"
-                ],
-                "regions": [
-                  "Global",
-                  "Canada East",
-                  "Canada Central"
-                ],
-                "receivers": {
-                  "app": [
-                    "alzcanadapubsec@microsoft.com"
-                  ],
-                  "email": [
-                    "alzcanadapubsec@microsoft.com"
-                  ],
-                  "sms": [
-                    {
-                      "countryCode": "1",
-                      "phoneNumber": "5555555555"
-                    }
-                  ],
-                  "voice": [
-                    {
-                      "countryCode": "1",
-                      "phoneNumber": "5555555555"
-                    }
-                  ]
-                },
-                "actionGroupName": "ALZ action group",
-                "actionGroupShortName": "alz-alert",
-                "alertRuleName": "ALZ alert rule",
-                "alertRuleDescription": "Alert rule for Azure Landing Zone"
+                  "resourceGroupName": "service-health",
+                  "incidentTypes": [ "Incident", "Security" ],
+                  "regions": [ "Global", "Canada East", "Canada Central" ],
+                  "receivers": {
+                      "app": [ "alzcanadapubsec@microsoft.com" ],
+                      "email": [ "alzcanadapubsec@microsoft.com" ],
+                      "sms": [ { "countryCode": "1", "phoneNumber": "5555555555" } ],
+                      "voice": [ { "countryCode": "1", "phoneNumber": "5555555555" } ]
+                  },
+                  "actionGroupName": "Service health action group",
+                  "actionGroupShortName": "health-alert",
+                  "alertRuleName": "Incidents and Security",
+                  "alertRuleDescription": "Service Health: Incidents and Security"
               }
             },
             "securityCenter": {
@@ -796,40 +775,19 @@ In order to configure audit stream for Azure Monitor, identify the following inf
               "parameters": {
                 "serviceHealthAlerts": {
                   "value": {
-                    "resourceGroupName": "pubsec-service-health",
-                    "incidentTypes": [
-                      "Incident",
-                      "Security"
-                    ],
-                    "regions": [
-                      "Global",
-                      "Canada East",
-                      "Canada Central"
-                    ],
-                    "receivers": {
-                      "app": [
-                        "alzcanadapubsec@microsoft.com"
-                      ],
-                      "email": [
-                        "alzcanadapubsec@microsoft.com"
-                      ],
-                      "sms": [
-                        {
-                          "countryCode": "1",
-                          "phoneNumber": "5555555555"
-                        }
-                      ],
-                      "voice": [
-                        {
-                          "countryCode": "1",
-                          "phoneNumber": "5555555555"
-                        }
-                      ]
-                    },
-                    "actionGroupName": "ALZ action group",
-                    "actionGroupShortName": "alz-alert",
-                    "alertRuleName": "ALZ alert rule",
-                    "alertRuleDescription": "Alert rule for Azure Landing Zone"
+                      "resourceGroupName": "service-health",
+                      "incidentTypes": [ "Incident", "Security" ],
+                      "regions": [ "Global", "Canada East", "Canada Central" ],
+                      "receivers": {
+                          "app": [ "alzcanadapubsec@microsoft.com" ],
+                          "email": [ "alzcanadapubsec@microsoft.com" ],
+                          "sms": [ { "countryCode": "1", "phoneNumber": "5555555555" } ],
+                          "voice": [ { "countryCode": "1", "phoneNumber": "5555555555" } ]
+                      },
+                      "actionGroupName": "Service health action group",
+                      "actionGroupShortName": "health-alert",
+                      "alertRuleName": "Incidents and Security",
+                      "alertRuleDescription": "Service Health: Incidents and Security"
                   }
                 },
                 "securityCenter": {
@@ -1055,40 +1013,19 @@ In order to configure audit stream for Azure Monitor, identify the following inf
               "parameters": {
                 "serviceHealthAlerts": {
                   "value": {
-                    "resourceGroupName": "pubsec-service-health",
-                    "incidentTypes": [
-                      "Incident",
-                      "Security"
-                    ],
-                    "regions": [
-                      "Global",
-                      "Canada East",
-                      "Canada Central"
-                    ],
-                    "receivers": {
-                      "app": [
-                        "alzcanadapubsec@microsoft.com"
-                      ],
-                      "email": [
-                        "alzcanadapubsec@microsoft.com"
-                      ],
-                      "sms": [
-                        {
-                          "countryCode": "1",
-                          "phoneNumber": "5555555555"
-                        }
-                      ],
-                      "voice": [
-                        {
-                          "countryCode": "1",
-                          "phoneNumber": "5555555555"
-                        }
-                      ]
-                    },
-                    "actionGroupName": "ALZ action group",
-                    "actionGroupShortName": "alz-alert",
-                    "alertRuleName": "ALZ alert rule",
-                    "alertRuleDescription": "Alert rule for Azure Landing Zone"
+                      "resourceGroupName": "service-health",
+                      "incidentTypes": [ "Incident", "Security" ],
+                      "regions": [ "Global", "Canada East", "Canada Central" ],
+                      "receivers": {
+                          "app": [ "alzcanadapubsec@microsoft.com" ],
+                          "email": [ "alzcanadapubsec@microsoft.com" ],
+                          "sms": [ { "countryCode": "1", "phoneNumber": "5555555555" } ],
+                          "voice": [ { "countryCode": "1", "phoneNumber": "5555555555" } ]
+                      },
+                      "actionGroupName": "Service health action group",
+                      "actionGroupShortName": "health-alert",
+                      "alertRuleName": "Incidents and Security",
+                      "alertRuleDescription": "Service Health: Incidents and Security"
                   }
                 },
                 "securityCenter": {

--- a/docs/onboarding/azure-devops-pipelines.md
+++ b/docs/onboarding/azure-devops-pipelines.md
@@ -1759,7 +1759,7 @@ Migration process:
               "value": < value from var-hubnetwork-resourceTags >
             },
             "resourceGroupName": {
-              "value": "< value from var-hubnetwork-azfwPolicyName >"
+              "value": "< value from var-hubnetwork-azfw-rgPolicyName >"
             },
             "policyName": {
               "value": "< value from var-hubnetwork-azfw-policyName >"
@@ -1803,26 +1803,26 @@ Migration process:
                 "privateDnsZones": {
                   "value": {
                     "enabled": < value from var-hubnetwork-deployPrivateDnsZones >,
-                    "resourceGroupName": "< value from var-hubnetworkPrivateDnsZonesName >"
+                    "resourceGroupName": "< value from var-hubnetwork-rgPrivateDnsZonesName >"
                   }
                 },
                 "ddosStandard": {
                   "value": {
                     "enabled": < value from var-hubnetwork-deployDdosStandard >,
-                    "resourceGroupName": "< value from var-hubnetworkDdosName >",
+                    "resourceGroupName": "< value from var-hubnetwork-rgDdosName >",
                     "planName": "< value from var-hubnetwork-ddosPlanName >"
                   }
                 },
                 "publicAccessZone": {
                   "value": {
                     "enabled": true,
-                    "resourceGroupName": "< value from var-hubnetworkPazName >"
+                    "resourceGroupName": "< value from var-hubnetwork-rgPazName >"
                   }
                 },
                 "managementRestrictedZone": {
                   "value": {
                     "enabled": true,
-                    "resourceGroupName": "< value from var-hubnetworkMrzName >",
+                    "resourceGroupName": "< value from var-hubnetwork-rgMrzName >",
                     "network": {
                       "name": "< value from var-hubnetwork-mrzVnetName >",
                       "addressPrefixes": [
@@ -1890,7 +1890,7 @@ Migration process:
                 },
                 "hub": {
                   "value": {
-                    "resourceGroupName": "< value from var-hubnetwork-azfwHubName >",
+                    "resourceGroupName": "< value from var-hubnetwork-azfw-rgHubName >",
                     "bastion": {
                       "enabled": true,
                       "name": "< value from var-hubnetwork-bastionName >",
@@ -1989,26 +1989,26 @@ Migration process:
             "privateDnsZones": {
               "value": {
                 "enabled": < value from var-hubnetwork-deployPrivateDnsZones >,
-                "resourceGroupName": "< value from var-hubnetworkPrivateDnsZonesName >"
+                "resourceGroupName": "< value from var-hubnetwork-rgPrivateDnsZonesName >"
               }
             },
             "ddosStandard": {
               "value": {
                 "enabled": < value from var-hubnetwork-deployDdosStandard >,
-                "resourceGroupName": "< value from var-hubnetworkDdosName >",
+                "resourceGroupName": "< value from var-hubnetwork-rgDdosName >",
                 "planName": "< value from var-hubnetwork-ddosPlanName >"
               }
             },
             "publicAccessZone": {
               "value": {
                 "enabled": true,
-                "resourceGroupName": "< value from var-hubnetworkPazName >"
+                "resourceGroupName": "< value from var-hubnetwork-rgPazName >"
               }
             },
             "managementRestrictedZone": {
               "value": {
                 "enabled": true,
-                "resourceGroupName": "< value from var-hubnetworkMrzName >",
+                "resourceGroupName": "< value from var-hubnetwork-rgMrzName >",
                 "network": {
                   "name": "< value from var-hubnetwork-mrzVnetName >",
                   "addressPrefixes": [
@@ -2076,7 +2076,7 @@ Migration process:
             },
             "hub": {
               "value": {
-                "resourceGroupName": "< value from var-hubnetwork-azfwHubName >",
+                "resourceGroupName": "< value from var-hubnetwork-azfw-rgHubName >",
                 "bastion": {
                   "enabled": true,
                   "name": "< value from var-hubnetwork-bastionName >",

--- a/docs/policy/readme.md
+++ b/docs/policy/readme.md
@@ -155,9 +155,9 @@ Parameters can be templated using the syntax `{{PARAMETER_NAME}}`.  Following pa
 | Templated Parameter | Source Value | Example |
 | --- | --- | --- |
 | {{var-topLevelManagementGroupName}} | Environment configuration file such as [config/variables/CanadaESLZ-main.yml](../../config/variables/CanadaESLZ-main.yml)  | `pubsec`
-| {{var-logging-logAnalyticsWorkspaceResourceId}} | Resource ID is inferred using Log Analytics settings in environment configuration file such as [config/variables/CanadaESLZ-main.yml](../../config/variables/CanadaESLZ-main.yml)  | `/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace`
+| {{var-logging-logAnalyticsWorkspaceResourceId}} | Resource ID is inferred using Log Analytics settings in environment configuration file such as [config/variables/CanadaESLZ-main.yml](../../config/variables/CanadaESLZ-main.yml)  | `/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace`
 | {{var-logging-logAnalyticsWorkspaceId}} |  Workspace ID is inferred using Log Analytics settings in environment configuration file such as [config/variables/CanadaESLZ-main.yml](../../config/variables/CanadaESLZ-main.yml) | `fcce3f30-158a-4561-a714-361623f42168`
-| {{var-logging-logAnalyticsResourceGroupName}} | Environment configuration file such as [config/variables/CanadaESLZ-main.yml](../../config/variables/CanadaESLZ-main.yml)  | `pubsec-central-logging-rg`
+| {{var-logging-logAnalyticsResourceGroupName}} | Environment configuration file such as [config/variables/CanadaESLZ-main.yml](../../config/variables/CanadaESLZ-main.yml)  | `pubsec-central-logging`
 | {{var-logging-logAnalyticsRetentionInDays}} | Environment configuration file such as [config/variables/CanadaESLZ-main.yml](../../config/variables/CanadaESLZ-main.yml) | `730`
 | {{var-logging-diagnosticSettingsforNetworkSecurityGroupsStoragePrefix}} | Environment configuration file such as [config/variables/CanadaESLZ-main.yml](../../config/variables/CanadaESLZ-main.yml)  | `pubsecnsg`
 | {{var-policyAssignmentManagementGroupId}} | The management group scope for policy assignment. | `pubsec`

--- a/landingzones/lz-generic-subscription/networking.bicep
+++ b/landingzones/lz-generic-subscription/networking.bicep
@@ -15,7 +15,7 @@ param location string = resourceGroup().location
 // -----------------------------
 // "hubNetwork": {
 //   "value": {
-//       "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+//       "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
 //       "rfc1918IPRange": "10.18.0.0/22",
 //       "rfc6598IPRange": "100.60.0.0/16",
 //       "egressVirtualApplianceIp": "10.18.0.36"
@@ -25,7 +25,7 @@ param location string = resourceGroup().location
 // Example (Bicep)
 // -----------------------------
 // {
-//   virtualNetworkId: '/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet'
+//   virtualNetworkId: '/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet'
 //   rfc1918IPRange: '10.18.0.0/22'
 //   rfc6598IPRange: '100.60.0.0/16'
 //   egressVirtualApplianceIp: '10.18.0.36'

--- a/landingzones/lz-healthcare/networking.bicep
+++ b/landingzones/lz-healthcare/networking.bicep
@@ -15,26 +15,26 @@ param location string = resourceGroup().location
 // -----------------------------
 // "hubNetwork": {
 //   "value": {
-//       "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+//       "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
 //       "rfc1918IPRange": "10.18.0.0/22",
 //       "rfc6598IPRange": "100.60.0.0/16",
 //       "egressVirtualApplianceIp": "10.18.0.36",
 //       "privateDnsManagedByHub": true,
 //       "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-//       "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+//       "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
 //   }
 // }
 
 // Example (Bicep)
 // -----------------------------
 // {
-//   virtualNetworkId: '/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet'
+//   virtualNetworkId: '/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet'
 //   rfc1918IPRange: '10.18.0.0/22'
 //   rfc6598IPRange: '100.60.0.0/16'
 //   egressVirtualApplianceIp: '10.18.0.36'
 //   privateDnsManagedByHub: true,
 //   privateDnsManagedByHubSubscriptionId: 'ed7f4eed-9010-4227-b115-2a5e37728f27',
-//   privateDnsManagedByHubResourceGroupName: 'pubsec-dns-rg'
+//   privateDnsManagedByHubResourceGroupName: 'pubsec-dns'
 // }
 @description('Hub Network configuration that includes virtualNetworkId, rfc1918IPRange, rfc6598IPRange, egressVirtualApplianceIp, privateDnsManagedByHub flag, privateDnsManagedByHubSubscriptionId and privateDnsManagedByHubResourceGroupName.')
 param hubNetwork object

--- a/landingzones/lz-machinelearning/networking.bicep
+++ b/landingzones/lz-machinelearning/networking.bicep
@@ -15,26 +15,26 @@ param location string = resourceGroup().location
 // -----------------------------
 // "hubNetwork": {
 //   "value": {
-//       "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+//       "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
 //       "rfc1918IPRange": "10.18.0.0/22",
 //       "rfc6598IPRange": "100.60.0.0/16",
 //       "egressVirtualApplianceIp": "10.18.0.36",
 //       "privateDnsManagedByHub": true,
 //       "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-//       "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+//       "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
 //   }
 // }
 
 // Example (Bicep)
 // -----------------------------
 // {
-//   virtualNetworkId: '/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet'
+//   virtualNetworkId: '/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet'
 //   rfc1918IPRange: '10.18.0.0/22'
 //   rfc6598IPRange: '100.60.0.0/16'
 //   egressVirtualApplianceIp: '10.18.0.36'
 //   privateDnsManagedByHub: true,
 //   privateDnsManagedByHubSubscriptionId: 'ed7f4eed-9010-4227-b115-2a5e37728f27',
-//   privateDnsManagedByHubResourceGroupName: 'pubsec-dns-rg'
+//   privateDnsManagedByHubResourceGroupName: 'pubsec-dns'
 // }
 @description('Hub Network configuration that includes virtualNetworkId, rfc1918IPRange, rfc6598IPRange, egressVirtualApplianceIp, privateDnsManagedByHub flag, privateDnsManagedByHubSubscriptionId and privateDnsManagedByHubResourceGroupName.')
 param hubNetwork object

--- a/schemas/latest/readme.md
+++ b/schemas/latest/readme.md
@@ -92,26 +92,26 @@
         "privateDnsZones": {
           "value": {
             "enabled": true,
-            "resourceGroupName": "pubsec-dns-rg"
+            "resourceGroupName": "pubsec-dns"
           }
         },
         "ddosStandard": {
           "value": {
             "enabled": false,
-            "resourceGroupName": "pubsec-ddos-rg",
+            "resourceGroupName": "pubsec-ddos",
             "planName": "ddos-plan"
           }
         },
         "publicAccessZone": {
           "value": {
             "enabled": true,
-            "resourceGroupName": "pubsec-public-access-zone-rg"
+            "resourceGroupName": "pubsec-public-access-zone"
           }
         },
         "managementRestrictedZone": {
           "value": {
             "enabled": true,
-            "resourceGroupName": "pubsec-management-restricted-zone-rg",
+            "resourceGroupName": "pubsec-management-restricted-zone",
             "network": {
               "name": "management-restricted-vnet",
               "addressPrefixes": ["10.18.4.0/22"],
@@ -177,7 +177,7 @@
         },
         "hub": {
           "value": {
-            "resourceGroupName": "pubsec-hub-networking-rg",
+            "resourceGroupName": "pubsec-hub-networking",
             "bastion": {
               "enabled": true,
               "name": "bastion",
@@ -327,26 +327,26 @@
         "privateDnsZones": {
           "value": {
             "enabled": true,
-            "resourceGroupName": "pubsec-dns-rg"
+            "resourceGroupName": "pubsec-dns"
           }
         },
         "ddosStandard": {
           "value": {
             "enabled": false,
-            "resourceGroupName": "pubsec-ddos-rg",
+            "resourceGroupName": "pubsec-ddos",
             "planName": "ddos-plan"
           }
         },
         "publicAccessZone": {
           "value": {
             "enabled": true,
-            "resourceGroupName": "pubsec-public-access-zone-rg"
+            "resourceGroupName": "pubsec-public-access-zone"
           }
         },
         "managementRestrictedZone": {
           "value": {
             "enabled": true,
-            "resourceGroupName": "pubsec-management-restricted-zone-rg",
+            "resourceGroupName": "pubsec-management-restricted-zone",
             "network": {
               "name": "management-restricted-vnet",
               "addressPrefixes": ["10.18.4.0/22"],
@@ -412,7 +412,7 @@
         },
         "hub": {
           "value": {
-            "resourceGroupName": "pubsec-hub-networking-rg",
+            "resourceGroupName": "pubsec-hub-networking",
             "bastion": {
               "enabled": true,
               "name": "bastion",

--- a/schemas/v0.5.0/readme.md
+++ b/schemas/v0.5.0/readme.md
@@ -92,26 +92,26 @@
         "privateDnsZones": {
           "value": {
             "enabled": true,
-            "resourceGroupName": "pubsec-dns-rg"
+            "resourceGroupName": "pubsec-dns"
           }
         },
         "ddosStandard": {
           "value": {
             "enabled": false,
-            "resourceGroupName": "pubsec-ddos-rg",
+            "resourceGroupName": "pubsec-ddos",
             "planName": "ddos-plan"
           }
         },
         "publicAccessZone": {
           "value": {
             "enabled": true,
-            "resourceGroupName": "pubsec-public-access-zone-rg"
+            "resourceGroupName": "pubsec-public-access-zone"
           }
         },
         "managementRestrictedZone": {
           "value": {
             "enabled": true,
-            "resourceGroupName": "pubsec-management-restricted-zone-rg",
+            "resourceGroupName": "pubsec-management-restricted-zone",
             "network": {
               "name": "management-restricted-vnet",
               "addressPrefixes": ["10.18.4.0/22"],
@@ -177,7 +177,7 @@
         },
         "hub": {
           "value": {
-            "resourceGroupName": "pubsec-hub-networking-rg",
+            "resourceGroupName": "pubsec-hub-networking",
             "bastion": {
               "enabled": true,
               "name": "bastion",
@@ -327,26 +327,26 @@
         "privateDnsZones": {
           "value": {
             "enabled": true,
-            "resourceGroupName": "pubsec-dns-rg"
+            "resourceGroupName": "pubsec-dns"
           }
         },
         "ddosStandard": {
           "value": {
             "enabled": false,
-            "resourceGroupName": "pubsec-ddos-rg",
+            "resourceGroupName": "pubsec-ddos",
             "planName": "ddos-plan"
           }
         },
         "publicAccessZone": {
           "value": {
             "enabled": true,
-            "resourceGroupName": "pubsec-public-access-zone-rg"
+            "resourceGroupName": "pubsec-public-access-zone"
           }
         },
         "managementRestrictedZone": {
           "value": {
             "enabled": true,
-            "resourceGroupName": "pubsec-management-restricted-zone-rg",
+            "resourceGroupName": "pubsec-management-restricted-zone",
             "network": {
               "name": "management-restricted-vnet",
               "addressPrefixes": ["10.18.4.0/22"],
@@ -412,7 +412,7 @@
         },
         "hub": {
           "value": {
-            "resourceGroupName": "pubsec-hub-networking-rg",
+            "resourceGroupName": "pubsec-hub-networking",
             "bastion": {
               "enabled": true,
               "name": "bastion",

--- a/tests/schemas/lz-generic-subscription/BackupRecoveryVaultIsFalse.json
+++ b/tests/schemas/lz-generic-subscription/BackupRecoveryVaultIsFalse.json
@@ -83,7 +83,7 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4"

--- a/tests/schemas/lz-generic-subscription/BackupRecoveryVaultIsTrue.json
+++ b/tests/schemas/lz-generic-subscription/BackupRecoveryVaultIsTrue.json
@@ -84,7 +84,7 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4"

--- a/tests/schemas/lz-generic-subscription/BudgetIsFalse.json
+++ b/tests/schemas/lz-generic-subscription/BudgetIsFalse.json
@@ -84,7 +84,7 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4"

--- a/tests/schemas/lz-generic-subscription/BudgetIsTrue.json
+++ b/tests/schemas/lz-generic-subscription/BudgetIsTrue.json
@@ -90,7 +90,7 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4"

--- a/tests/schemas/lz-generic-subscription/EmptyResourceTags.json
+++ b/tests/schemas/lz-generic-subscription/EmptyResourceTags.json
@@ -77,7 +77,7 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4"

--- a/tests/schemas/lz-generic-subscription/EmptySubscriptionTags.json
+++ b/tests/schemas/lz-generic-subscription/EmptySubscriptionTags.json
@@ -88,7 +88,7 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4"

--- a/tests/schemas/lz-generic-subscription/FullDeployment-With-Hub.json
+++ b/tests/schemas/lz-generic-subscription/FullDeployment-With-Hub.json
@@ -70,7 +70,7 @@
             }
         },
         "logAnalyticsWorkspaceResourceId": {
-            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
         },
         "resourceGroups": {
             "value": {
@@ -93,7 +93,7 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4"

--- a/tests/schemas/lz-generic-subscription/FullDeployment-With-Location.json
+++ b/tests/schemas/lz-generic-subscription/FullDeployment-With-Location.json
@@ -73,7 +73,7 @@
             }
         },
         "logAnalyticsWorkspaceResourceId": {
-            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
         },
         "resourceGroups": {
             "value": {
@@ -96,7 +96,7 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4"

--- a/tests/schemas/lz-generic-subscription/FullDeployment-Without-Hub.json
+++ b/tests/schemas/lz-generic-subscription/FullDeployment-Without-Hub.json
@@ -70,7 +70,7 @@
             }
         },
         "logAnalyticsWorkspaceResourceId": {
-            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
         },
         "resourceGroups": {
             "value": {

--- a/tests/schemas/lz-generic-subscription/WithoutCustomDNS.json
+++ b/tests/schemas/lz-generic-subscription/WithoutCustomDNS.json
@@ -84,7 +84,7 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4"

--- a/tests/schemas/lz-generic-subscription/WithoutSubnets.json
+++ b/tests/schemas/lz-generic-subscription/WithoutSubnets.json
@@ -84,7 +84,7 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4"

--- a/tests/schemas/lz-healthcare/BudgetIsFalse.json
+++ b/tests/schemas/lz-healthcare/BudgetIsFalse.json
@@ -104,13 +104,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/BudgetIsTrue.json
+++ b/tests/schemas/lz-healthcare/BudgetIsTrue.json
@@ -110,13 +110,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/EmptyResourceTags.json
+++ b/tests/schemas/lz-healthcare/EmptyResourceTags.json
@@ -102,13 +102,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/EmptySubscriptionTags.json
+++ b/tests/schemas/lz-healthcare/EmptySubscriptionTags.json
@@ -107,13 +107,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/FullDeployment-With-Hub.json
+++ b/tests/schemas/lz-healthcare/FullDeployment-With-Hub.json
@@ -70,7 +70,7 @@
             }
         },
         "logAnalyticsWorkspaceResourceId": {
-            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
         },
         "resourceGroups": {
             "value": {
@@ -116,13 +116,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/FullDeployment-With-Location.json
+++ b/tests/schemas/lz-healthcare/FullDeployment-With-Location.json
@@ -73,7 +73,7 @@
             }
         },
         "logAnalyticsWorkspaceResourceId": {
-            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
         },
         "resourceGroups": {
             "value": {
@@ -119,13 +119,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/FullDeployment-With-OptionalSubnets.json
+++ b/tests/schemas/lz-healthcare/FullDeployment-With-OptionalSubnets.json
@@ -70,7 +70,7 @@
             }
         },
         "logAnalyticsWorkspaceResourceId": {
-            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
         },
         "resourceGroups": {
             "value": {
@@ -116,13 +116,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/FullDeployment-Without-Hub.json
+++ b/tests/schemas/lz-healthcare/FullDeployment-Without-Hub.json
@@ -70,7 +70,7 @@
             }
         },
         "logAnalyticsWorkspaceResourceId": {
-            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+            "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
         },
         "resourceGroups": {
             "value": {

--- a/tests/schemas/lz-healthcare/SQLDB-aadAuthOnly.json
+++ b/tests/schemas/lz-healthcare/SQLDB-aadAuthOnly.json
@@ -113,13 +113,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/SQLDB-mixedAuth.json
+++ b/tests/schemas/lz-healthcare/SQLDB-mixedAuth.json
@@ -114,13 +114,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/SQLDB-sqlAuth.json
+++ b/tests/schemas/lz-healthcare/SQLDB-sqlAuth.json
@@ -111,13 +111,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/SQLDBIsFalse.json
+++ b/tests/schemas/lz-healthcare/SQLDBIsFalse.json
@@ -109,13 +109,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/Synapse-aadAuthOnly.json
+++ b/tests/schemas/lz-healthcare/Synapse-aadAuthOnly.json
@@ -112,13 +112,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/Synapse-mixedAuth.json
+++ b/tests/schemas/lz-healthcare/Synapse-mixedAuth.json
@@ -113,13 +113,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/Synapse-sqlAuth.json
+++ b/tests/schemas/lz-healthcare/Synapse-sqlAuth.json
@@ -110,13 +110,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-healthcare/WithoutCMK.json
+++ b/tests/schemas/lz-healthcare/WithoutCMK.json
@@ -113,13 +113,13 @@
         },
         "hubNetwork": {
             "value": {
-                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+                "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
                 "rfc1918IPRange": "10.18.0.0/22",
                 "rfc6598IPRange": "100.60.0.0/16",
                 "egressVirtualApplianceIp": "10.18.1.4",
                 "privateDnsManagedByHub": true,
                 "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-                "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+                "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
             }
         },
         "network": {

--- a/tests/schemas/lz-machinelearning/AKS-AzureCNI-AzureNP.json
+++ b/tests/schemas/lz-machinelearning/AKS-AzureCNI-AzureNP.json
@@ -136,13 +136,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/AKS-AzureCNI-Calico.json
+++ b/tests/schemas/lz-machinelearning/AKS-AzureCNI-Calico.json
@@ -136,13 +136,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/AKS-Kubenet-Calico.json
+++ b/tests/schemas/lz-machinelearning/AKS-Kubenet-Calico.json
@@ -136,13 +136,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/AKSIsFalse.json
+++ b/tests/schemas/lz-machinelearning/AKSIsFalse.json
@@ -129,13 +129,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/AppServiceLinuxContainerIsFalse.json
+++ b/tests/schemas/lz-machinelearning/AppServiceLinuxContainerIsFalse.json
@@ -133,13 +133,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/AppServiceLinuxContainerPrivateEndpointIsFalse.json
+++ b/tests/schemas/lz-machinelearning/AppServiceLinuxContainerPrivateEndpointIsFalse.json
@@ -136,13 +136,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/BudgetIsFalse.json
+++ b/tests/schemas/lz-machinelearning/BudgetIsFalse.json
@@ -127,13 +127,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/BudgetIsTrue.json
+++ b/tests/schemas/lz-machinelearning/BudgetIsTrue.json
@@ -133,13 +133,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/EmptyResourceTags.json
+++ b/tests/schemas/lz-machinelearning/EmptyResourceTags.json
@@ -126,13 +126,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/EmptySubscriptionTags.json
+++ b/tests/schemas/lz-machinelearning/EmptySubscriptionTags.json
@@ -131,13 +131,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/FullDeployment-With-Hub.json
+++ b/tests/schemas/lz-machinelearning/FullDeployment-With-Hub.json
@@ -70,7 +70,7 @@
       }
     },
     "logAnalyticsWorkspaceResourceId": {
-      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
     },
     "resourceGroups": {
       "value": {
@@ -138,13 +138,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/FullDeployment-With-Location.json
+++ b/tests/schemas/lz-machinelearning/FullDeployment-With-Location.json
@@ -73,7 +73,7 @@
       }
     },
     "logAnalyticsWorkspaceResourceId": {
-      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
     },
     "resourceGroups": {
       "value": {
@@ -141,13 +141,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/FullDeployment-With-OptionalSubnets.json
+++ b/tests/schemas/lz-machinelearning/FullDeployment-With-OptionalSubnets.json
@@ -70,7 +70,7 @@
       }
     },
     "logAnalyticsWorkspaceResourceId": {
-      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
     },
     "resourceGroups": {
       "value": {
@@ -138,13 +138,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/FullDeployment-Without-Hub.json
+++ b/tests/schemas/lz-machinelearning/FullDeployment-Without-Hub.json
@@ -70,7 +70,7 @@
       }
     },
     "logAnalyticsWorkspaceResourceId": {
-      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
     },
     "resourceGroups": {
       "value": {

--- a/tests/schemas/lz-machinelearning/SQLDB-aadAuthOnly.json
+++ b/tests/schemas/lz-machinelearning/SQLDB-aadAuthOnly.json
@@ -135,13 +135,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/SQLDB-mixedAuth.json
+++ b/tests/schemas/lz-machinelearning/SQLDB-mixedAuth.json
@@ -136,13 +136,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/SQLDB-sqlAuth.json
+++ b/tests/schemas/lz-machinelearning/SQLDB-sqlAuth.json
@@ -133,13 +133,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/SQLDBIsFalse.json
+++ b/tests/schemas/lz-machinelearning/SQLDBIsFalse.json
@@ -131,13 +131,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/SQLMIIsFalse.json
+++ b/tests/schemas/lz-machinelearning/SQLMIIsFalse.json
@@ -130,13 +130,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-machinelearning/WithoutCMK.json
+++ b/tests/schemas/lz-machinelearning/WithoutCMK.json
@@ -135,13 +135,13 @@
     },
     "hubNetwork": {
       "value": {
-        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet",
+        "virtualNetworkId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourceGroups/pubsec-hub-networking/providers/Microsoft.Network/virtualNetworks/hub-vnet",
         "rfc1918IPRange": "10.18.0.0/22",
         "rfc6598IPRange": "100.60.0.0/16",
         "egressVirtualApplianceIp": "10.18.1.4",
         "privateDnsManagedByHub": true,
         "privateDnsManagedByHubSubscriptionId": "ed7f4eed-9010-4227-b115-2a5e37728f27",
-        "privateDnsManagedByHubResourceGroupName": "pubsec-dns-rg"
+        "privateDnsManagedByHubResourceGroupName": "pubsec-dns"
       }
     },
     "network": {

--- a/tests/schemas/lz-platform-connectivity-hub-azfw-policy/FullDeployment.json
+++ b/tests/schemas/lz-platform-connectivity-hub-azfw-policy/FullDeployment.json
@@ -13,7 +13,7 @@
       }
     },
     "resourceGroupName": {
-      "value": "pubsec-azure-firewall-policy-rg"
+      "value": "pubsec-azure-firewall-policy"
     },
     "policyName": {
       "value": "pubsecAzureFirewallPolicy"

--- a/tests/schemas/lz-platform-connectivity-hub-azfw/BudgetIsFalse.json
+++ b/tests/schemas/lz-platform-connectivity-hub-azfw/BudgetIsFalse.json
@@ -59,26 +59,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -146,7 +146,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/tests/schemas/lz-platform-connectivity-hub-azfw/FullDeployment-With-OptionalHubSubnets.json
+++ b/tests/schemas/lz-platform-connectivity-hub-azfw/FullDeployment-With-OptionalHubSubnets.json
@@ -65,26 +65,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -152,7 +152,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/tests/schemas/lz-platform-connectivity-hub-azfw/FullDeployment-WithAzureFirewallPolicy.json
+++ b/tests/schemas/lz-platform-connectivity-hub-azfw/FullDeployment-WithAzureFirewallPolicy.json
@@ -65,26 +65,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -152,7 +152,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",
@@ -168,7 +168,7 @@
           ],
           "forcedTunnelingEnabled": false,
           "forcedTunnelingNextHop": "10.17.1.4",
-          "firewallPolicyId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourcegroups/pubsec-azure-firewall-policy-rg/providers/Microsoft.Network/firewallPolicies/pubsecAzureFirewallPolicy"
+          "firewallPolicyId": "/subscriptions/ed7f4eed-9010-4227-b115-2a5e37728f27/resourcegroups/pubsec-azure-firewall-policy/providers/Microsoft.Network/firewallPolicies/pubsecAzureFirewallPolicy"
         },
         "network": {
           "name": "hub-vnet",

--- a/tests/schemas/lz-platform-connectivity-hub-azfw/FullDeployment-WithLogAnalyticsWorkspace.json
+++ b/tests/schemas/lz-platform-connectivity-hub-azfw/FullDeployment-WithLogAnalyticsWorkspace.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "logAnalyticsWorkspaceResourceId": {
-      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
     },
     "serviceHealthAlerts": {
       "value": {
@@ -68,26 +68,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -155,7 +155,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/tests/schemas/lz-platform-connectivity-hub-azfw/FullDeployment-Without-ManagementRestrictedZone.json
+++ b/tests/schemas/lz-platform-connectivity-hub-azfw/FullDeployment-Without-ManagementRestrictedZone.json
@@ -65,26 +65,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -96,7 +96,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/tests/schemas/lz-platform-connectivity-hub-azfw/FullDeployment.json
+++ b/tests/schemas/lz-platform-connectivity-hub-azfw/FullDeployment.json
@@ -65,26 +65,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -152,7 +152,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/tests/schemas/lz-platform-connectivity-hub-nva/BudgetIsFalse.json
+++ b/tests/schemas/lz-platform-connectivity-hub-nva/BudgetIsFalse.json
@@ -59,26 +59,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -146,7 +146,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/tests/schemas/lz-platform-connectivity-hub-nva/FullDeployment-With-FortigateBYOL.json
+++ b/tests/schemas/lz-platform-connectivity-hub-nva/FullDeployment-With-FortigateBYOL.json
@@ -65,26 +65,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -152,7 +152,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/tests/schemas/lz-platform-connectivity-hub-nva/FullDeployment-With-OptionalHubSubnets.json
+++ b/tests/schemas/lz-platform-connectivity-hub-nva/FullDeployment-With-OptionalHubSubnets.json
@@ -65,26 +65,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -152,7 +152,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/tests/schemas/lz-platform-connectivity-hub-nva/FullDeployment-With-Ubuntu.json
+++ b/tests/schemas/lz-platform-connectivity-hub-nva/FullDeployment-With-Ubuntu.json
@@ -65,26 +65,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -152,7 +152,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/tests/schemas/lz-platform-connectivity-hub-nva/FullDeployment-WithLogAnalyticsWorkspace.json
+++ b/tests/schemas/lz-platform-connectivity-hub-nva/FullDeployment-WithLogAnalyticsWorkspace.json
@@ -3,7 +3,7 @@
   "contentVersion": "1.0.0.0",
   "parameters": {
     "logAnalyticsWorkspaceResourceId": {
-      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging-rg/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
+      "value": "/subscriptions/bc0a4f9f-07fa-4284-b1bd-fbad38578d3a/resourcegroups/pubsec-central-logging/providers/microsoft.operationalinsights/workspaces/log-analytics-workspace"
     },
     "serviceHealthAlerts": {
       "value": {
@@ -68,26 +68,26 @@
     "privateDnsZones": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-dns-rg"
+        "resourceGroupName": "pubsec-dns"
       }
     },
     "ddosStandard": {
       "value": {
         "enabled": false,
-        "resourceGroupName": "pubsec-ddos-rg",
+        "resourceGroupName": "pubsec-ddos",
         "planName": "ddos-plan"
       }
     },
     "publicAccessZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-public-access-zone-rg"
+        "resourceGroupName": "pubsec-public-access-zone"
       }
     },
     "managementRestrictedZone": {
       "value": {
         "enabled": true,
-        "resourceGroupName": "pubsec-management-restricted-zone-rg",
+        "resourceGroupName": "pubsec-management-restricted-zone",
         "network": {
           "name": "management-restricted-vnet",
           "addressPrefixes": [
@@ -155,7 +155,7 @@
     },
     "hub": {
       "value": {
-        "resourceGroupName": "pubsec-hub-networking-rg",
+        "resourceGroupName": "pubsec-hub-networking",
         "bastion": {
           "enabled": true,
           "name": "bastion",

--- a/tests/schemas/lz-platform-logging/BudgetIsFalse.json
+++ b/tests/schemas/lz-platform-logging/BudgetIsFalse.json
@@ -57,7 +57,7 @@
       }
     },
     "logAnalyticsResourceGroupName": {
-      "value": "pubsec-central-logging-rg"
+      "value": "pubsec-central-logging"
     },
     "logAnalyticsWorkspaceName": {
       "value": "log-analytics-workspace"

--- a/tests/schemas/lz-platform-logging/EmptyResourceTags.json
+++ b/tests/schemas/lz-platform-logging/EmptyResourceTags.json
@@ -56,7 +56,7 @@
       "value": {}
     },
     "logAnalyticsResourceGroupName": {
-      "value": "pubsec-central-logging-rg"
+      "value": "pubsec-central-logging"
     },
     "logAnalyticsWorkspaceName": {
       "value": "log-analytics-workspace"

--- a/tests/schemas/lz-platform-logging/EmptySubscriptionTags.json
+++ b/tests/schemas/lz-platform-logging/EmptySubscriptionTags.json
@@ -61,7 +61,7 @@
       }
     },
     "logAnalyticsResourceGroupName": {
-      "value": "pubsec-central-logging-rg"
+      "value": "pubsec-central-logging"
     },
     "logAnalyticsWorkspaceName": {
       "value": "log-analytics-workspace"

--- a/tests/schemas/lz-platform-logging/FullDeployment-With-Location.json
+++ b/tests/schemas/lz-platform-logging/FullDeployment-With-Location.json
@@ -66,7 +66,7 @@
       }
     },
     "logAnalyticsResourceGroupName": {
-      "value": "pubsec-central-logging-rg"
+      "value": "pubsec-central-logging"
     },
     "logAnalyticsWorkspaceName": {
       "value": "log-analytics-workspace"

--- a/tests/schemas/lz-platform-logging/FullDeployment.json
+++ b/tests/schemas/lz-platform-logging/FullDeployment.json
@@ -63,7 +63,7 @@
       }
     },
     "logAnalyticsResourceGroupName": {
-      "value": "pubsec-central-logging-rg"
+      "value": "pubsec-central-logging"
     },
     "logAnalyticsWorkspaceName": {
       "value": "log-analytics-workspace"

--- a/tests/schemas/lz-platform-logging/WithoutSubscriptionRoleAssignments.json
+++ b/tests/schemas/lz-platform-logging/WithoutSubscriptionRoleAssignments.json
@@ -55,7 +55,7 @@
       }
     },
     "logAnalyticsResourceGroupName": {
-      "value": "pubsec-central-logging-rg"
+      "value": "pubsec-central-logging"
     },
     "logAnalyticsWorkspaceName": {
       "value": "log-analytics-workspace"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Related to #307.

- Removes `-rg` suffix from resource group names in Logging & Hub Networking examples. 

## This PR fixes/adds/changes/removes

Fixes #306 

### Breaking Changes

None

## Testing Evidence

_**Pending**_

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
