### PR TITLE
Fix typo in onboarding guidance

### DIFF
--- a/docs/onboarding/azure-devops-pipelines.md
+++ b/docs/onboarding/azure-devops-pipelines.md
@@ -1319,7 +1319,7 @@ In order to configure audit stream for Azure Monitor, identify the following inf
       * For **CanadaPubSecALZ v0.8.0 or earlier**, this is based on the prefix defined in `var-topLevelManagementGroupName`.  For example, if `var-topLevelManagementGroupName` is set to `contoso`, then `var-hubnetwork-managementGroupId` will be `contosoPlatformConnectivity`.
 
      * Set `var-hubnetwork-region` with preferred Azure region.
-     * Set `var-hubnetwork-subscriptionId` with subscription id for logging.
+     * Set `var-hubnetwork-subscriptionId` with subscription id for networking.
      * When using Hub Networking with Azure Firewall
         * Set `var-hubnetwork-azfwPolicy-configurationFileName` with the file name of the Azure Firewall Policy configuration.  i.e. `hub-azfw-policy/azure-firewall-policy.parameters.json`
         * Set `var-hubnetwork-azfw-configurationFileName` with the file name of the Hub Networking configuration.  i.e. `hub-azfw/hub-network.parameters.json`


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Updating a typo on pipeline.md documentation

## This PR fixes/adds/changes/removes

Replaced logging subscription Id with networking subscription Id in the documentation for implementing hub networking pipeline

### Breaking Changes

NA

## Testing Evidence
NA
## As part of this Pull Request I have
NA
- [ ] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [ ] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
