### PR TITLE
Resolve linter warning: prefer-unquoted-property-names

### DIFF
--- a/azresources/containers/aks/aks-with-cmk.bicep
+++ b/azresources/containers/aks/aks-with-cmk.bicep
@@ -206,7 +206,7 @@ resource aks 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
       clientId: 'msi'
     }
     addonProfiles: {
-      'omsagent': (!empty(containerInsightsLogAnalyticsResourceId)) ? {
+      omsagent: (!empty(containerInsightsLogAnalyticsResourceId)) ? {
         enabled: true
         config: {
           logAnalyticsWorkspaceResourceID: containerInsightsLogAnalyticsResourceId

--- a/azresources/containers/aks/aks-without-cmk.bicep
+++ b/azresources/containers/aks/aks-without-cmk.bicep
@@ -156,7 +156,7 @@ resource aks 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
       clientId: 'msi'
     }
     addonProfiles: {
-      'omsagent': (!empty(containerInsightsLogAnalyticsResourceId)) ? {
+      omsagent: (!empty(containerInsightsLogAnalyticsResourceId)) ? {
         enabled: true
         config: {
           logAnalyticsWorkspaceResourceID: containerInsightsLogAnalyticsResourceId

--- a/landingzones/lz-generic-subscription/networking.bicep
+++ b/landingzones/lz-generic-subscription/networking.bicep
@@ -309,5 +309,5 @@ output vnetName string = vnet.name
 output vnetPeered bool = network.peerToHubVirtualNetwork
 
 output subnets array = [for subnet in network.subnets: {
-  'id': '${vnet.id}/subnets/${subnet.name}'
+  id: '${vnet.id}/subnets/${subnet.name}'
 }]

--- a/landingzones/lz-platform-connectivity-hub-azfw/mrz/mrz-vnet.bicep
+++ b/landingzones/lz-platform-connectivity-hub-azfw/mrz/mrz-vnet.bicep
@@ -70,5 +70,5 @@ output vnetName string = vnet.name
 output vnetId string = vnet.id
 
 output subnets array = [for subnet in network.subnets: {
-  'id': '${vnet.id}/subnets/${subnet.name}'
+  id: '${vnet.id}/subnets/${subnet.name}'
 }]

--- a/landingzones/lz-platform-connectivity-hub-nva/mrz/mrz-vnet.bicep
+++ b/landingzones/lz-platform-connectivity-hub-nva/mrz/mrz-vnet.bicep
@@ -70,5 +70,5 @@ output vnetName string = vnet.name
 output vnetId string = vnet.id
 
 output subnets array = [for subnet in network.subnets: {
-  'id': '${vnet.id}/subnets/${subnet.name}'
+  id: '${vnet.id}/subnets/${subnet.name}'
 }]

--- a/policy/custom/definitions/policyset/Tags.bicep
+++ b/policy/custom/definitions/policyset/Tags.bicep
@@ -36,7 +36,7 @@ resource tagsInheritedFromSubscriptionToResourceGroupPolicy 'Microsoft.Authoriza
   name: toLower(replace('tags-inherited-from-sub-to-rg-${tag}', ' ', '-'))
   properties: {
     metadata: {
-      'tag': tag
+      tag: tag
     }
     displayName: '${tagsInheritedFromSubscriptionToResourceGroupPolicyTemplate.properties.displayName}: ${tag}'
     mode: tagsInheritedFromSubscriptionToResourceGroupPolicyTemplate.properties.mode
@@ -66,7 +66,7 @@ resource tagsInheritedFromResourceGroupPolicy 'Microsoft.Authorization/policyDef
   name: toLower(replace('tags-inherited-from-rg-${tag}', ' ', '-'))
   properties: {
     metadata: {
-      'tag': tag
+      tag: tag
     }
     displayName: '${tagsInheritedFromResourceGroupPolicyTemplate.properties.displayName}: ${tag}'
     mode: tagsInheritedFromResourceGroupPolicyTemplate.properties.mode
@@ -96,7 +96,7 @@ resource tagsRequiredOnResourceGroupPolicy 'Microsoft.Authorization/policyDefini
   name: toLower(replace('Tags-Require-Tag-ResourceGroup-${tag}', ' ', '-'))
   properties: {
     metadata: {
-      'tag': tag
+      tag: tag
     }
     displayName: '${tagsRequiredOnResourceGroupPolicyTemplate.properties.displayName}: ${tag}'
     mode: tagsRequiredOnResourceGroupPolicyTemplate.properties.mode
@@ -129,7 +129,7 @@ resource tagsAuditOnResourcePolicy 'Microsoft.Authorization/policyDefinitions@20
   name: toLower(replace('Tags-Audit-Missing-Tag-Resource-${tag}', ' ', '-'))
   properties: {
     metadata: {
-      'tag': tag
+      tag: tag
     }
     displayName: '${tagsAuditOnResourcePolicyTemplate.properties.displayName}: ${tag}'
     mode: tagsAuditOnResourcePolicyTemplate.properties.mode


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Resolve linter warning introduced in Bicep `v0.8.2`.

## This PR fixes/adds/changes/removes

Fixes #321 

### Breaking Changes

None

## Testing Evidence

- Verified pipelines execute to deploy
  - Hub Networking with Azure Firewall
  - Hub Networking with NVA
  - Azure Policy (tag definitions)
  - Generic Subscription
- Verified Tag Policy definition has no functional differences
- Verified Hub Networking and Generic Subscription outputs has no functional differences
- Verified AKS (with and without CMK) deployed with Container Insights attached to Log Analytics Workspace
- Verified no linter warnings for `prefer-unquoted-property-names`

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
