### PR TITLE
PrivateLink support for MySql Flexible Databases

### DIFF
--- a/policy/custom/definitions/policyset/DNSPrivateEndpoints.parameters.json
+++ b/policy/custom/definitions/policyset/DNSPrivateEndpoints.parameters.json
@@ -242,6 +242,15 @@
                     ]
                 },
                 {
+                    "privateLinkServiceNamespace": "Microsoft.DBforMySQL/flexibleServers",
+                    "zone": "privatelink.mysql.database.azure.com",
+                    "filterLocationLike": "*",
+                    "groupId": "mysqlServer",
+                    "privateDnsZoneConfigs": [
+                        "privatelink.mysql.database.azure.com"
+                    ]
+                },
+                {
                     "privateLinkServiceNamespace": "Microsoft.DBforMariaDB/servers",
                     "zone": "privatelink.mariadb.database.azure.com",
                     "filterLocationLike": "*",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. #387 

### Breaking Changes

1. N/A

## Testing Evidence

Private Endpoint Policy for MySQL Flexible databases has been created:
<img width="491" alt="image" src="https://github.com/Azure/CanadaPubSecALZ/assets/51492255/8f7e8b41-4303-4c8c-92a5-4c796dce46b1">

Namespace is set to: Microsoft.DBforMySQL/flexibleServers
<img width="931" alt="image" src="https://github.com/Azure/CanadaPubSecALZ/assets/51492255/5e90e789-084d-404a-a43c-d747880e8f40">


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
