### PR TITLE
Removed "#Requires -Modules" from the PS scripts

### DIFF
--- a/scripts/configuration/Get-AlzConfiguration.ps1
+++ b/scripts/configuration/Get-AlzConfiguration.ps1
@@ -40,8 +40,6 @@ Param(
   [ref]$ConfigVariablesByRef
 )
 
-#Requires -Modules powershell-yaml
-
 $ErrorActionPreference = "Stop"
 
 $RepoConfigPath = (Resolve-Path -Path "$RepoRootPath/config/variables/$Environment.yml").Path

--- a/scripts/configuration/New-AlzConfiguration.ps1
+++ b/scripts/configuration/New-AlzConfiguration.ps1
@@ -72,8 +72,6 @@ Param(
   [string]$UserConfigPath = "$UserRootPath/ALZ/config"
 )
 
-#Requires -Modules powershell-yaml
-
 $ErrorActionPreference = "Stop"
 
 function ValidateParameters {

--- a/scripts/configuration/New-AlzCredential.ps1
+++ b/scripts/configuration/New-AlzCredential.ps1
@@ -61,8 +61,6 @@ Param(
   [string]$UserConfigPath = "$UserRootPath/ALZ/config"
 )
 
-#Requires -Modules Az
-
 $ErrorActionPreference = "Stop"
 
 function CreateServicePrincipal {

--- a/scripts/configuration/New-AlzDeployment.ps1
+++ b/scripts/configuration/New-AlzDeployment.ps1
@@ -86,8 +86,6 @@ Param(
   [string]$UserConfigPath = "$UserRootPath/ALZ/config"
 )
 
-#Requires -Modules Az, powershell-yaml, PSPasswordGenerator
-
 $ErrorActionPreference = "Stop"
 
 #region Functions

--- a/scripts/configuration/Remove-AlzCredential.ps1
+++ b/scripts/configuration/Remove-AlzCredential.ps1
@@ -61,8 +61,6 @@ Param(
   [string]$UserConfigPath = "$UserRootPath/ALZ/config"
 )
 
-#Requires -Modules Az
-
 $ErrorActionPreference = "Stop"
 
 function RemoveServicePrincipal {

--- a/scripts/configuration/Test-AlzCredential.ps1
+++ b/scripts/configuration/Test-AlzCredential.ps1
@@ -61,8 +61,6 @@ Param(
   [string]$UserConfigPath = "$UserRootPath/ALZ/config"
 )
 
-#Requires -Modules Az
-
 $ErrorActionPreference = "Stop"
 
 function TestServicePrincipal {

--- a/scripts/deployments/Functions/EnvironmentContext.ps1
+++ b/scripts/deployments/Functions/EnvironmentContext.ps1
@@ -8,8 +8,6 @@ EITHER EXPRESSED OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE IMPLIED WARRANTIES
 OF MERCHANTABILITY AND/OR FITNESS FOR A PARTICULAR PURPOSE.
 ----------------------------------------------------------------------------------
 #>
-
-#Requires -Modules powershell-yaml
  
 Import-Module powershell-yaml
 

--- a/scripts/deployments/RunWorkflows.ps1
+++ b/scripts/deployments/RunWorkflows.ps1
@@ -191,8 +191,6 @@ Param(
   [SecureString]$NvaPassword=$null
 )
 
-#Requires -Modules Az, powershell-yaml
-
 $ErrorActionPreference = "Stop"
 
 # In order to use this End to End script, you must configure ARM template configurations for Logging, Networking and Subscriptions.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

The PowerShell scripts fail when trying to execute "#Requires" line in RunWorkflows.ps1 and EnvironmentContext.ps1 after the recent Az module update.

Additionally #Requires statement exists in other onboarding scripts like:
scripts/configuration/Get-AlzConfiguration.ps1
scripts/configuration/New-AlzCredential.ps1
scripts/configuration/Remove-AlzCredential.ps1
scripts/configuration/New-AlzDeployment.ps1
scripts/configuration/New-AlzConfiguration.ps1
scripts/configuration/Test-AlzCredential.ps1

This change simply removes the statement from the scripts, since prerequisites are already installed for the script execution.

## This PR fixes/adds/changes/removes

1. Fixed #392 

### Breaking Changes

1. N/A

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

I tested the GitHub Actions after the #Requires statement removal in my own environment and GitHub actions were able to successfully execute the PowerShell scripts (tested with the "Management Groups" pipeline).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
