### PR TITLE
Update la-vminsights-readonly.bicep to fix typo in action

### DIFF
--- a/roles/la-vminsights-readonly.bicep
+++ b/roles/la-vminsights-readonly.bicep
@@ -34,7 +34,7 @@ resource roleDefn 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' =
         actions: [
           'Microsoft.operationalinsights/workspaces/features/generateMap/read'
           'Microsoft.operationalinsights/workspaces/features/servergroups/members/read'
-          'Microsoft.operationalinsights/workspaces/features/clientgroups/memebers/read'
+          'Microsoft.operationalinsights/workspaces/features/clientgroups/members/read'
           'Microsoft.operationalinsights/workspaces/features/machineGroups/read'
           'Microsoft.OperationalInsights/workspaces/query/VMBoundPort/read'
           'Microsoft.OperationalInsights/workspaces/query/VMComputer/read'


### PR DESCRIPTION
Typo in action: "memebers" should be "members"

