### PR TITLE
Update la-vminsights-readonly.bicep

### DIFF
--- a/roles/la-vminsights-readonly.bicep
+++ b/roles/la-vminsights-readonly.bicep
@@ -34,7 +34,7 @@ resource roleDefn 'Microsoft.Authorization/roleDefinitions@2018-01-01-preview' =
         actions: [
           'Microsoft.operationalinsights/workspaces/features/generateMap/read'
           'Microsoft.operationalinsights/workspaces/features/servergroups/members/read'
-          'Microsoft.operationalinsights/workspaces/features/clientgroups/memebers/read'
+          'Microsoft.operationalinsights/workspaces/features/clientgroups/members/read'
           'Microsoft.operationalinsights/workspaces/features/machineGroups/read'
           'Microsoft.OperationalInsights/workspaces/query/VMBoundPort/read'
           'Microsoft.OperationalInsights/workspaces/query/VMComputer/read'


### PR DESCRIPTION
## Overview/Summary

Fixing an issue with action name typo

## This PR fixes

Issue #404

la-vminsights-readonly.bicep line 37 has a typo.

Currently reads
'Microsoft.operationalinsights/workspaces/features/clientgroups/memebers/read'
should read
'Microsoft.operationalinsights/workspaces/features/clientgroups/members/read'

"Memebers" should be "Members"

### Breaking Changes

None

## Testing Evidence

/usr/bin/az account clear
Finishing: Custom Role - la-vminsights-readonly.bicep

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/azure/CanadaPubSecALZ/pulls)
- [X] Associated it with relevant [GitHub Issues](https://github.com/azure/CanadaPubSecALZ/issues)
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/azure/CanadaPubSecALZ/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
